### PR TITLE
feat: implement xsd:byte codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,27 @@ We are incrementally implementing the RDF-compatible subset of XSD 1.1 types:
 | **Durations** | `xsd:duration` | 🏗️ | `XsdDuration` |
 | | `xsd:yearMonthDuration` | 🏗️ | `XsdDuration` |
 | | `xsd:dayTimeDuration` | 🏗️ | `XsdDuration` |
-| **Limited-range Integers** | `xsd:byte`, `xsd:short`, `xsd:int`, `xsd:long` | 🏗️ | `int` / `BigInt` |
-| | `xsd:unsignedByte`, `xsd:unsignedShort`, `xsd:unsignedInt`, `xsd:unsignedLong` | 🏗️ | `int` / `BigInt` |
-| | `xsd:positiveInteger`, `xsd:nonNegativeInteger` | 🏗️ | `BigInt` |
-| | `xsd:negativeInteger`, `xsd:nonPositiveInteger` | 🏗️ | `BigInt` |
+| **Limited-range Integers** | `xsd:byte` | ✅ | `XsdByte` |
+| | `xsd:short` | 🏗️ | `int` |
+| | `xsd:int` | 🏗️ | `int` |
+| | `xsd:long` | 🏗️ | `int` / `BigInt` |
+| | `xsd:unsignedByte` | 🏗️ | `int` |
+| | `xsd:unsignedShort` | 🏗️ | `int` |
+| | `xsd:unsignedInt` | 🏗️ | `int` |
+| | `xsd:unsignedLong` | 🏗️ | `BigInt` |
+| | `xsd:positiveInteger` | 🏗️ | `BigInt` |
+| | `xsd:nonNegativeInteger` | 🏗️ | `BigInt` |
+| | `xsd:negativeInteger` | 🏗️ | `BigInt` |
+| | `xsd:nonPositiveInteger` | 🏗️ | `BigInt` |
 | **Encoded Binary** | `xsd:hexBinary` | 🏗️ | `Uint8List` |
 | | `xsd:base64Binary` | 🏗️ | `Uint8List` |
 | **Miscellaneous** | `xsd:anyURI` | 🏗️ | `Uri` |
-| | `xsd:language`, `xsd:token`, `xsd:NMTOKEN` | 🏗️ | `String` |
-| | `xsd:Name`, `xsd:NCName`, `xsd:normalizedString` | 🏗️ | `String` |
+| | `xsd:language` | 🏗️ | `String` |
+| | `xsd:token` | 🏗️ | `String` |
+| | `xsd:NMTOKEN` | 🏗️ | `String` |
+| | `xsd:Name` | 🏗️ | `String` |
+| | `xsd:NCName` | 🏗️ | `String` |
+| | `xsd:normalizedString` | 🏗️ | `String` |
 
 ## Compliance
 

--- a/lib/src/codecs/byte.dart
+++ b/lib/src/codecs/byte.dart
@@ -1,0 +1,82 @@
+import '../core/exceptions.dart';
+import '../core/whitespace.dart';
+import '../core/xsd_codec.dart';
+
+/// Extension type on [int] representing the `xsd:byte` value space.
+///
+/// Value space: Integers in the range `[-128, 127]`.
+extension type const XsdByte._(int value) implements int {
+  /// Validates and creates an [XsdByte].
+  ///
+  /// Throws an [ArgumentError] if the value is outside the range `[-128, 127]`.
+  factory XsdByte(int value) {
+    if (value < -128 || value > 127) {
+      throw RangeError.range(value, -128, 127, 'XsdByte');
+    }
+    return XsdByte._(value);
+  }
+
+  /// Creates an [XsdByte] without validation.
+  const XsdByte.unsafe(this.value);
+}
+
+/// Codec for `xsd:byte`.
+///
+/// According to XSD 1.1:
+/// - Value space: Integers in the range `[-128, 127]`.
+/// - Base type: `xsd:short`.
+/// - whiteSpace facet: collapse (fixed)
+/// - pattern: [\-+]?[0-9]+
+class XsdByteCodec extends XsdCodec<XsdByte> {
+  /// Creates a new [XsdByteCodec].
+  const XsdByteCodec();
+
+  @override
+  XsdWhitespace get whiteSpace => XsdWhitespace.collapse;
+
+  @override
+  XsdConverter<XsdByte, String> get encoder => const XsdByteEncoder();
+
+  @override
+  XsdConverter<String, XsdByte> get decoder => const XsdByteDecoder();
+}
+
+/// Encoder for `xsd:byte`.
+class XsdByteEncoder extends XsdConverter<XsdByte, String> {
+  /// Creates a new [XsdByteEncoder].
+  const XsdByteEncoder();
+
+  @override
+  String convert(XsdByte input) => input.toString();
+}
+
+/// Decoder for `xsd:byte`.
+class XsdByteDecoder extends XsdConverter<String, XsdByte> {
+  /// Creates a new [XsdByteDecoder].
+  const XsdByteDecoder();
+
+  static final RegExp _pattern = RegExp(r'^[\-+]?[0-9]+$');
+
+  @override
+  XsdByte convert(String input) {
+    if (!_pattern.hasMatch(input)) {
+      throw XsdValidationException(
+        'Invalid xsd:byte lexical representation.',
+        input: input,
+        type: 'xsd:byte',
+      );
+    }
+
+    final value = int.parse(input);
+
+    if (value < -128 || value > 127) {
+      throw XsdValidationException(
+        'Value out of range for xsd:byte: $value',
+        input: input,
+        type: 'xsd:byte',
+      );
+    }
+
+    return XsdByte.unsafe(value);
+  }
+}

--- a/lib/src/core/facade.dart
+++ b/lib/src/core/facade.dart
@@ -1,4 +1,5 @@
 import '../codecs/boolean.dart';
+import '../codecs/byte.dart';
 
 /// Global facade for XSD codecs.
 const xsd = XsdFacade._();
@@ -9,4 +10,7 @@ class XsdFacade {
 
   /// Codec for `xsd:boolean`.
   XsdBooleanCodec get boolean => const XsdBooleanCodec();
+
+  /// Codec for `xsd:byte`.
+  XsdByteCodec get byte => const XsdByteCodec();
 }

--- a/lib/xsd.dart
+++ b/lib/xsd.dart
@@ -4,6 +4,7 @@
 library;
 
 export 'src/codecs/boolean.dart';
+export 'src/codecs/byte.dart';
 export 'src/core/exceptions.dart';
 export 'src/core/facade.dart';
 export 'src/core/xsd_codec.dart';

--- a/test/codecs/byte_test.dart
+++ b/test/codecs/byte_test.dart
@@ -1,0 +1,112 @@
+import 'package:test/test.dart';
+import 'package:xsd/src/codecs/byte.dart';
+import 'package:xsd/src/core/exceptions.dart';
+
+void main() {
+  group('XsdByte', () {
+    test('XsdByte() factory validates range', () {
+      expect(XsdByte(127).value, 127);
+      expect(XsdByte(-128).value, -128);
+      expect(() => XsdByte(128), throwsRangeError);
+      expect(() => XsdByte(-129), throwsRangeError);
+    });
+
+    test('XsdByte.unsafe() bypasses validation', () {
+      const b = XsdByte.unsafe(1000); // Should not throw
+      expect(b.value, 1000);
+    });
+  });
+
+  group('XsdByteCodec', () {
+    const codec = XsdByteCodec();
+
+    group('decode', () {
+      test('accepts valid bytes', () {
+        expect(codec.decode('127'), const XsdByte.unsafe(127));
+        expect(codec.decode('-128'), const XsdByte.unsafe(-128));
+        expect(codec.decode('0'), const XsdByte.unsafe(0));
+        expect(codec.decode('100'), const XsdByte.unsafe(100));
+        expect(codec.decode('-100'), const XsdByte.unsafe(-100));
+      });
+
+      test('accepts valid lexical variations', () {
+        expect(codec.decode('+127'), const XsdByte.unsafe(127));
+        expect(codec.decode('+0'), const XsdByte.unsafe(0));
+        expect(codec.decode('007'), const XsdByte.unsafe(7));
+        expect(codec.decode('-007'), const XsdByte.unsafe(-7));
+      });
+
+      test('accepts whitespace variations (collapse)', () {
+        expect(codec.decode(' 127'), const XsdByte.unsafe(127));
+        expect(codec.decode('0 '), const XsdByte.unsafe(0));
+        expect(codec.decode('\n-128'), const XsdByte.unsafe(-128));
+        expect(codec.decode('\r\n 100 \t'), const XsdByte.unsafe(100));
+        expect(codec.decode('  -50  '), const XsdByte.unsafe(-50));
+        expect(
+          () => codec.decode(' + 10 '),
+          throwsA(isA<XsdValidationException>()),
+          reason:
+              'Internal whitespace in "+ 10" collapses to "+ 10" '
+              'which is invalid for xsd:byte pattern',
+        );
+      });
+
+      test('throws XsdValidationException for out of range values', () {
+        expect(
+          () => codec.decode('128'),
+          throwsA(isA<XsdValidationException>()),
+        );
+        expect(
+          () => codec.decode('-129'),
+          throwsA(isA<XsdValidationException>()),
+        );
+        expect(
+          () => codec.decode('1000'),
+          throwsA(isA<XsdValidationException>()),
+        );
+        expect(
+          () => codec.decode('-1000'),
+          throwsA(isA<XsdValidationException>()),
+        );
+      });
+
+      test('throws XsdValidationException for invalid formats', () {
+        expect(
+          () => codec.decode('1.0'),
+          throwsA(isA<XsdValidationException>()),
+        );
+        expect(
+          () => codec.decode('abc'),
+          throwsA(isA<XsdValidationException>()),
+        );
+        expect(() => codec.decode(''), throwsA(isA<XsdValidationException>()));
+        expect(
+          () => codec.decode('+-1'),
+          throwsA(isA<XsdValidationException>()),
+        );
+        expect(
+          () => codec.decode('-+1'),
+          throwsA(isA<XsdValidationException>()),
+        );
+        expect(
+          () => codec.decode('1-'),
+          throwsA(isA<XsdValidationException>()),
+        );
+        expect(
+          () => codec.decode('1+'),
+          throwsA(isA<XsdValidationException>()),
+        );
+      });
+    });
+
+    group('encode', () {
+      test('encodes values to canonical lexical representation', () {
+        expect(codec.encode(const XsdByte.unsafe(127)), '127');
+        expect(codec.encode(const XsdByte.unsafe(-128)), '-128');
+        expect(codec.encode(const XsdByte.unsafe(0)), '0');
+        expect(codec.encode(const XsdByte.unsafe(7)), '7');
+        expect(codec.encode(const XsdByte.unsafe(-7)), '-7');
+      });
+    });
+  });
+}


### PR DESCRIPTION
- Add `XsdByte` extension type with range validation ([-128, 127]).
- Implement `XsdByteCodec` with whitespace collapse strategy.
- Add comprehensive tests for `xsd:byte` decoding and encoding.
- Update global `xsd` facade and library exports.
- Refactor README.md supported datatypes table for better clarity.