### PR TITLE
feat: implement xsd:decimal codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ We are incrementally implementing the RDF-compatible subset of XSD 1.1 types:
 | :--- | :--- | :--- | :--- |
 | **Core types** | `xsd:string` | 🏗️ | `String` |
 | | `xsd:boolean` | ✅ | `bool` |
-| | `xsd:decimal` | 🏗️ | `XsdDecimal` |
+| | `xsd:decimal` | ✅ | `XsdDecimal` |
 | | `xsd:integer` | 🏗️ | `BigInt` |
 | **IEEE Floating-Point** | `xsd:double` | 🏗️ | `double` |
 | | `xsd:float` | 🏗️ | `double` |

--- a/lib/src/codecs/decimal.dart
+++ b/lib/src/codecs/decimal.dart
@@ -1,0 +1,175 @@
+import 'package:meta/meta.dart';
+import '../core/exceptions.dart';
+import '../core/whitespace.dart';
+import '../core/xsd_codec.dart';
+
+/// Represents an arbitrary-precision decimal number as defined by W3C XSD 1.1.
+///
+/// It is backed by an unscaled value (BigInt) and a scale (int).
+/// For example, 12.34 is represented as unscaledValue: 1234, scale: 2.
+@immutable
+final class XsdDecimal implements Comparable<XsdDecimal> {
+  /// The digits of the number ignoring the decimal point.
+  final BigInt unscaledValue;
+
+  /// The number of digits to the right of the decimal point.
+  final int scale;
+
+  /// Creates an [XsdDecimal] with the given [unscaledValue] and [scale].
+  ///
+  /// The value is mathematically normalized by stripping trailing fractional zeros.
+  /// For example, [XsdDecimal(BigInt.from(12300), 2)] becomes unscaled: 123, scale: 0.
+  factory XsdDecimal(BigInt unscaledValue, int scale) {
+    var currentUnscaled = unscaledValue;
+    var currentScale = scale;
+
+    if (currentUnscaled == BigInt.zero) {
+      currentScale = 0;
+    } else {
+      while (currentScale > 0 &&
+          currentUnscaled % BigInt.from(10) == BigInt.zero) {
+        currentUnscaled ~/= BigInt.from(10);
+        currentScale -= 1;
+      }
+    }
+
+    return XsdDecimal._(currentUnscaled, currentScale);
+  }
+
+  const XsdDecimal._(this.unscaledValue, this.scale);
+
+  /// Parses an [input] string into an [XsdDecimal].
+  ///
+  /// The [input] must conform to the XSD 1.1 lexical representation for decimal:
+  /// `(\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)`
+  ///
+  /// Scientific notation (e.g., '1E2') and special values (NaN, INF) are not supported.
+  factory XsdDecimal.parse(String input) {
+    final regex = RegExp(r'^(\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)$');
+    final match = regex.firstMatch(input);
+
+    if (match == null) {
+      throw FormatException('Invalid XSD decimal: $input');
+    }
+
+    final sign = match.group(1) == '-' ? -1 : 1;
+    final magnitude = match.group(2)!;
+
+    final dotIndex = magnitude.indexOf('.');
+    if (dotIndex == -1) {
+      return XsdDecimal(BigInt.parse(magnitude) * BigInt.from(sign), 0);
+    } else {
+      final beforeDot = magnitude.substring(0, dotIndex);
+      final afterDot = magnitude.substring(dotIndex + 1);
+      final unscaledString = '$beforeDot$afterDot';
+      final scale = afterDot.length;
+
+      // Handle case like ".5" where unscaledString might be empty if beforeDot is empty
+      // but BigInt.parse handles leading dot if we combine them correctly.
+      // Actually if beforeDot is empty, it's like "0" + afterDot.
+      final unscaledValue = BigInt.parse(
+        unscaledString.isEmpty ? '0' : unscaledString,
+      );
+      return XsdDecimal(unscaledValue * BigInt.from(sign), scale);
+    }
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is XsdDecimal &&
+          unscaledValue == other.unscaledValue &&
+          scale == other.scale;
+
+  @override
+  int get hashCode => unscaledValue.hashCode ^ scale.hashCode;
+
+  @override
+  int compareTo(XsdDecimal other) {
+    if (scale == other.scale) {
+      return unscaledValue.compareTo(other.unscaledValue);
+    }
+
+    // To compare, we bring both to the same scale (the larger one)
+    if (scale > other.scale) {
+      final factor = BigInt.from(10).pow(scale - other.scale);
+      return unscaledValue.compareTo(other.unscaledValue * factor);
+    } else {
+      final factor = BigInt.from(10).pow(other.scale - scale);
+      return (unscaledValue * factor).compareTo(other.unscaledValue);
+    }
+  }
+
+  @override
+  String toString() {
+    if (scale == 0) {
+      return unscaledValue.toString();
+    }
+
+    final isNegative = unscaledValue < BigInt.zero;
+    var absUnscaled = unscaledValue.abs().toString();
+
+    if (absUnscaled.length <= scale) {
+      absUnscaled = absUnscaled.padLeft(scale + 1, '0');
+    }
+
+    final dotPosition = absUnscaled.length - scale;
+    final result =
+        '${absUnscaled.substring(0, dotPosition)}.${absUnscaled.substring(dotPosition)}';
+
+    return isNegative ? '-$result' : result;
+  }
+}
+
+/// Codec for `xsd:decimal`.
+///
+/// According to XSD 1.1:
+/// - Value space: subset of real numbers expressible as i / 10^n (n >= 0).
+/// - Lexical representation: (\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)
+/// - whiteSpace facet: collapse (fixed)
+/// - Canonical representation:
+///   - If integer: no decimal point.
+///   - If not integer: decimal point required, leading zero required if < 1.
+///   - Leading/trailing zeros prohibited (except for one leading zero before .).
+///   - Sign: '-' preserved, '+' omitted.
+class XsdDecimalCodec extends XsdCodec<XsdDecimal> {
+  /// Creates a new [XsdDecimalCodec].
+  const XsdDecimalCodec();
+
+  @override
+  XsdWhitespace get whiteSpace => XsdWhitespace.collapse;
+
+  @override
+  XsdConverter<XsdDecimal, String> get encoder => const XsdDecimalEncoder();
+
+  @override
+  XsdConverter<String, XsdDecimal> get decoder => const XsdDecimalDecoder();
+}
+
+/// Encoder for `xsd:decimal`.
+class XsdDecimalEncoder extends XsdConverter<XsdDecimal, String> {
+  /// Creates a new [XsdDecimalEncoder].
+  const XsdDecimalEncoder();
+
+  @override
+  String convert(XsdDecimal input) => input.toString();
+}
+
+/// Decoder for `xsd:decimal`.
+class XsdDecimalDecoder extends XsdConverter<String, XsdDecimal> {
+  /// Creates a new [XsdDecimalDecoder].
+  const XsdDecimalDecoder();
+
+  @override
+  XsdDecimal convert(String input) {
+    try {
+      return XsdDecimal.parse(input);
+    } on FormatException catch (e) {
+      throw XsdValidationException(
+        e.message,
+        input: input,
+        type: 'xsd:decimal',
+      );
+    }
+  }
+}

--- a/lib/src/core/facade.dart
+++ b/lib/src/core/facade.dart
@@ -1,5 +1,6 @@
 import '../codecs/boolean.dart';
 import '../codecs/byte.dart';
+import '../codecs/decimal.dart';
 
 /// Global facade for XSD codecs.
 const xsd = XsdFacade._();
@@ -13,4 +14,7 @@ class XsdFacade {
 
   /// Codec for `xsd:byte`.
   XsdByteCodec get byte => const XsdByteCodec();
+
+  /// Codec for `xsd:decimal`.
+  XsdDecimalCodec get decimal => const XsdDecimalCodec();
 }

--- a/lib/xsd.dart
+++ b/lib/xsd.dart
@@ -5,6 +5,7 @@ library;
 
 export 'src/codecs/boolean.dart';
 export 'src/codecs/byte.dart';
+export 'src/codecs/decimal.dart';
 export 'src/core/exceptions.dart';
 export 'src/core/facade.dart';
 export 'src/core/xsd_codec.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
+  meta: ^1.18.1
   # path: ^1.9.0
 
 dev_dependencies:

--- a/test/codecs/decimal_test.dart
+++ b/test/codecs/decimal_test.dart
@@ -1,0 +1,110 @@
+import 'package:test/test.dart';
+import 'package:xsd/src/codecs/decimal.dart';
+
+void main() {
+  group('XsdDecimal Core', () {
+    test('Internal normalization strips trailing fractional zeros', () {
+      final d1 = XsdDecimal(BigInt.from(12300), 2); // 123.00
+      expect(d1.unscaledValue, equals(BigInt.from(123)));
+      expect(d1.scale, equals(0));
+
+      final d2 = XsdDecimal(BigInt.from(12345), 3); // 12.345
+      expect(d2.unscaledValue, equals(BigInt.from(12345)));
+      expect(d2.scale, equals(3));
+
+      final d3 = XsdDecimal(BigInt.zero, 5); // 0.00000
+      expect(d3.unscaledValue, equals(BigInt.zero));
+      expect(d3.scale, equals(0));
+    });
+
+    test('Equality and hashCode', () {
+      final d1 = XsdDecimal(BigInt.from(123), 0); // 123
+      final d2 = XsdDecimal(BigInt.from(1230), 1); // 123.0
+      final d3 = XsdDecimal(BigInt.from(12300), 2); // 123.00
+
+      expect(d1, equals(d2));
+      expect(d1, equals(d3));
+      expect(d1.hashCode, equals(d2.hashCode));
+      expect(d1.hashCode, equals(d3.hashCode));
+    });
+
+    test('Comparable implementation', () {
+      final d1 = XsdDecimal(BigInt.from(10), 0); // 10
+      final d2 = XsdDecimal(BigInt.from(20), 0); // 20
+      final d3 = XsdDecimal(BigInt.from(15), 0); // 15
+
+      final list = [d2, d1, d3];
+      list.sort();
+
+      expect(list, equals([d1, d3, d2]));
+    });
+  });
+
+  group('XsdDecimal Parsing', () {
+    test('Valid lexical representations', () {
+      expect(XsdDecimal.parse('123'), equals(XsdDecimal(BigInt.from(123), 0)));
+      expect(
+        XsdDecimal.parse('123.456'),
+        equals(XsdDecimal(BigInt.from(123456), 3)),
+      );
+      expect(
+        XsdDecimal.parse('+123.456'),
+        equals(XsdDecimal(BigInt.from(123456), 3)),
+      );
+      expect(
+        XsdDecimal.parse('-123.456'),
+        equals(XsdDecimal(BigInt.from(-123456), 3)),
+      );
+      expect(XsdDecimal.parse('.5'), equals(XsdDecimal(BigInt.from(5), 1)));
+      expect(XsdDecimal.parse('-.5'), equals(XsdDecimal(BigInt.from(-5), 1)));
+      expect(XsdDecimal.parse('+.5'), equals(XsdDecimal(BigInt.from(5), 1)));
+      expect(XsdDecimal.parse('1.'), equals(XsdDecimal(BigInt.one, 0)));
+      expect(XsdDecimal.parse('0.0'), equals(XsdDecimal(BigInt.zero, 0)));
+      expect(XsdDecimal.parse('-0.0'), equals(XsdDecimal(BigInt.zero, 0)));
+      expect(
+        XsdDecimal.parse('007.50'),
+        equals(XsdDecimal(BigInt.from(75), 1)),
+      );
+    });
+
+    test('Invalid lexical representations', () {
+      expect(() => XsdDecimal.parse('1E2'), throwsFormatException);
+      expect(() => XsdDecimal.parse('NaN'), throwsFormatException);
+      expect(() => XsdDecimal.parse('INF'), throwsFormatException);
+      expect(() => XsdDecimal.parse('-INF'), throwsFormatException);
+      expect(() => XsdDecimal.parse('123.456.789'), throwsFormatException);
+      expect(() => XsdDecimal.parse('abc'), throwsFormatException);
+      expect(() => XsdDecimal.parse(''), throwsFormatException);
+      expect(() => XsdDecimal.parse('.'), throwsFormatException);
+    });
+  });
+
+  group('XsdDecimalCodec', () {
+    const codec = XsdDecimalCodec();
+
+    test('encode (Canonical Lexical Mapping)', () {
+      expect(codec.encode(XsdDecimal(BigInt.from(123), 0)), equals('123'));
+      expect(codec.encode(XsdDecimal(BigInt.from(1230), 1)), equals('123'));
+      expect(
+        codec.encode(XsdDecimal(BigInt.from(-123456), 3)),
+        equals('-123.456'),
+      );
+      expect(codec.encode(XsdDecimal(BigInt.from(5), 1)), equals('0.5'));
+      expect(codec.encode(XsdDecimal(BigInt.from(-5), 1)), equals('-0.5'));
+      expect(codec.encode(XsdDecimal(BigInt.from(75), 1)), equals('7.5'));
+      expect(codec.encode(XsdDecimal(BigInt.zero, 0)), equals('0'));
+      expect(codec.encode(XsdDecimal(BigInt.zero, 5)), equals('0'));
+    });
+
+    test('decode', () {
+      expect(
+        codec.decode('123.456'),
+        equals(XsdDecimal(BigInt.from(123456), 3)),
+      );
+      expect(
+        codec.decode('  123.456  '),
+        equals(XsdDecimal(BigInt.from(123456), 3)),
+      );
+    });
+  });
+}


### PR DESCRIPTION
- Add `XsdDecimal` class for arbitrary-precision decimal handling.
- Implement `XsdDecimalCodec` with whitespace collapse and canonical lexical mapping.
- Add comprehensive tests for `xsd:decimal` parsing, encoding, and normalization.
- Update global `xsd` facade and library exports to include `xsd:decimal`.
- Update README.md status for `xsd:decimal`.
- Add `meta` dependency for `@immutable` annotation.