### PR TITLE
feat(codec): implement xsd:double codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ We are incrementally implementing the RDF-compatible subset of XSD 1.1 types:
 | | `xsd:boolean` | ✅ | `bool` |
 | | `xsd:decimal` | ✅ | `XsdDecimal` |
 | | `xsd:integer` | 🏗️ | `BigInt` |
-| **IEEE Floating-Point** | `xsd:double` | 🏗️ | `double` |
+| **IEEE Floating-Point** | `xsd:double` | ✅ | `double` |
 | | `xsd:float` | 🏗️ | `double` |
 | **Time and Date** | `xsd:date` | 🏗️ | `XsdDate` |
 | | `xsd:time` | 🏗️ | `XsdTime` |

--- a/lib/src/codecs/double.dart
+++ b/lib/src/codecs/double.dart
@@ -1,0 +1,119 @@
+import '../core/exceptions.dart';
+import '../core/whitespace.dart';
+import '../core/xsd_codec.dart';
+
+/// Codec for `xsd:double`.
+///
+/// According to XSD 1.1:
+/// - Value space: IEEE double-precision 64-bit floating point.
+/// - whiteSpace facet: collapse (fixed).
+class XsdDoubleCodec extends XsdCodec<double> {
+  /// Creates a new [XsdDoubleCodec].
+  const XsdDoubleCodec();
+
+  @override
+  XsdWhitespace get whiteSpace => XsdWhitespace.collapse;
+
+  @override
+  XsdConverter<double, String> get encoder => const XsdDoubleEncoder();
+
+  @override
+  XsdConverter<String, double> get decoder => const XsdDoubleDecoder();
+}
+
+/// Encoder for `xsd:double`.
+class XsdDoubleEncoder extends XsdConverter<double, String> {
+  /// Creates a new [XsdDoubleEncoder].
+  const XsdDoubleEncoder();
+
+  @override
+  String convert(double input) {
+    if (input.isNaN) return 'NaN';
+    if (input == double.infinity) return 'INF';
+    if (input == double.negativeInfinity) return '-INF';
+
+    // Handle zero variants
+    if (input == 0.0) {
+      return input.isNegative ? '-0.0E0' : '0.0E0';
+    }
+
+    // Canonical form: mantissa has exactly one non-zero digit before decimal point.
+    // Example: 1.2345E2
+    // Dart's toStringAsExponential(decimalPlaces) provides scientific notation.
+    // However, toStringAsExponential does not specify a fixed number of digits
+    // unless we provide one, but XSD canonical form says "the mantissa MUST have
+    // exactly one non-zero digit before the decimal point" AND "the fractional part
+    // MUST be represented as a decimal number...".
+
+    // Actually, the simplest way is to use toStringAsExponential() and then
+    // clean it up if necessary (e.g. 'e' -> 'E', remove unnecessary '+' in exponent).
+
+    // W3C Canonical Mapping for double:
+    // "the mantissa is a decimal number... with one non-zero digit to the left of
+    // the decimal point... The exponent is an integer... with no leading zeroes."
+
+    var result = input.toStringAsExponential();
+
+    // Normalize exponent: replace 'e' with 'E' and remove '+'
+    result = result.replaceFirst('e', 'E').replaceFirst('E+', 'E');
+
+    // Ensure decimal point exists in mantissa even for integers like 1.0E0
+    // Dart's toStringAsExponential() usually includes it if needed, but let's check.
+    // e.g. 1.toStringAsExponential() -> '1e+0' (on some platforms) or '1.0e+0'
+    final eIndex = result.indexOf('E');
+    final mantissa = result.substring(0, eIndex);
+    final exponent = result.substring(eIndex);
+
+    if (!mantissa.contains('.')) {
+      result = '$mantissa.0$exponent';
+    }
+
+    return result;
+  }
+}
+
+/// Decoder for `xsd:double`.
+class XsdDoubleDecoder extends XsdConverter<String, double> {
+  /// Creates a new [XsdDoubleDecoder].
+  const XsdDoubleDecoder();
+
+  @override
+  double convert(String input) {
+    // Special literals
+    switch (input) {
+      case 'INF':
+      case '+INF':
+        return double.infinity;
+      case '-INF':
+        return double.negativeInfinity;
+      case 'NaN':
+        return double.nan;
+    }
+
+    // XSD 1.1 doubleRep regex: (\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)([Ee](\+|-)?[0-9]+)?
+    // Note: Dart's double.parse is fairly compatible but we must ensure it doesn't
+    // accept strings that XSD prohibits (like 'Infinity').
+
+    // We explicitly reject literals that double.parse might accept but XSD doesn't.
+    // 1. 'Infinity' variants
+    // 2. Case-variants of 'NaN' (Dart's double.parse is case-insensitive for 'NaN')
+    if (input.contains('Infinity') ||
+        (input.toLowerCase().contains('nan') && input != 'NaN')) {
+      throw XsdValidationException(
+        'Invalid xsd:double lexical form: $input',
+        input: input,
+        type: 'xsd:double',
+      );
+    }
+
+    try {
+      return double.parse(input);
+    } on FormatException {
+      throw XsdValidationException(
+        'Invalid xsd:double lexical form: $input',
+        input: input,
+        type: 'xsd:double',
+      );
+    }
+  }
+}

--- a/lib/src/core/facade.dart
+++ b/lib/src/core/facade.dart
@@ -1,6 +1,7 @@
 import '../codecs/boolean.dart';
 import '../codecs/byte.dart';
 import '../codecs/decimal.dart';
+import '../codecs/double.dart';
 
 /// Global facade for XSD codecs.
 const xsd = XsdFacade._();
@@ -17,4 +18,7 @@ class XsdFacade {
 
   /// Codec for `xsd:decimal`.
   XsdDecimalCodec get decimal => const XsdDecimalCodec();
+
+  /// Codec for `xsd:double`.
+  XsdDoubleCodec get double => const XsdDoubleCodec();
 }

--- a/lib/xsd.dart
+++ b/lib/xsd.dart
@@ -6,6 +6,7 @@ library;
 export 'src/codecs/boolean.dart';
 export 'src/codecs/byte.dart';
 export 'src/codecs/decimal.dart';
+export 'src/codecs/double.dart';
 export 'src/core/exceptions.dart';
 export 'src/core/facade.dart';
 export 'src/core/xsd_codec.dart';

--- a/test/codecs/double_test.dart
+++ b/test/codecs/double_test.dart
@@ -1,0 +1,99 @@
+import 'package:test/test.dart';
+import 'package:xsd/src/codecs/double.dart';
+import 'package:xsd/src/core/exceptions.dart';
+
+void main() {
+  group('XsdDoubleDecoder', () {
+    const decoder = XsdDoubleDecoder();
+
+    test('parses normal decimals', () {
+      expect(decoder.convert('123.45'), equals(123.45));
+      expect(decoder.convert('0.0'), equals(0.0));
+      expect(decoder.convert('.5'), equals(0.5));
+      expect(decoder.convert('1.'), equals(1.0));
+      expect(decoder.convert('+123.45'), equals(123.45));
+
+      // Check for negative zero explicitly
+      final negZero = decoder.convert('-0.0');
+      expect(negZero, equals(0.0));
+      expect(negZero.isNegative, isTrue);
+    });
+
+    test('parses scientific notation', () {
+      expect(decoder.convert('1.2345E2'), equals(123.45));
+      expect(decoder.convert('1.2345e2'), equals(123.45));
+      expect(decoder.convert('12.345E1'), equals(123.45));
+      expect(decoder.convert('1.2E-2'), equals(0.012));
+      expect(decoder.convert('0.0E0'), equals(0.0));
+
+      // Check for negative zero explicitly
+      final negZeroExp = decoder.convert('-0.0E0');
+      expect(negZeroExp, equals(0.0));
+      expect(negZeroExp.isNegative, isTrue);
+    });
+
+    test('parses special literals', () {
+      expect(decoder.convert('INF'), equals(double.infinity));
+      expect(decoder.convert('+INF'), equals(double.infinity));
+      expect(decoder.convert('-INF'), equals(double.negativeInfinity));
+      expect(decoder.convert('NaN'), isNaN);
+    });
+
+    test('throws XsdValidationException for invalid input', () {
+      expect(
+        () => decoder.convert('abc'),
+        throwsA(isA<XsdValidationException>()),
+      );
+      expect(
+        () => decoder.convert('1.2.3'),
+        throwsA(isA<XsdValidationException>()),
+      );
+      expect(
+        () => decoder.convert('++1'),
+        throwsA(isA<XsdValidationException>()),
+      );
+      expect(
+        () => decoder.convert('Infinity'), // XSD uses INF
+        throwsA(isA<XsdValidationException>()),
+      );
+
+      // Case sensitivity checks (Dart double.parse might accept these natively)
+      expect(
+        () => decoder.convert('nan'),
+        throwsA(isA<XsdValidationException>()),
+      );
+      expect(
+        () => decoder.convert('NAN'),
+        throwsA(isA<XsdValidationException>()),
+      );
+      expect(
+        () => decoder.convert('inf'),
+        throwsA(isA<XsdValidationException>()),
+      );
+    });
+  });
+
+  group('XsdDoubleEncoder', () {
+    const encoder = XsdDoubleEncoder();
+
+    test('encodes special values', () {
+      expect(encoder.convert(double.infinity), equals('INF'));
+      expect(encoder.convert(double.negativeInfinity), equals('-INF'));
+      expect(encoder.convert(double.nan), equals('NaN'));
+    });
+
+    test('encodes zeros in canonical form', () {
+      expect(encoder.convert(0.0), equals('0.0E0'));
+      expect(encoder.convert(-0.0), equals('-0.0E0'));
+    });
+
+    test('encodes normal values in canonical scientific notation', () {
+      expect(encoder.convert(123.45), equals('1.2345E2'));
+      expect(encoder.convert(0.012), equals('1.2E-2'));
+      expect(encoder.convert(1.0), equals('1.0E0'));
+      expect(encoder.convert(-1.0), equals('-1.0E0'));
+      expect(encoder.convert(10.0), equals('1.0E1'));
+      expect(encoder.convert(0.1), equals('1.0E-1'));
+    });
+  });
+}


### PR DESCRIPTION
Implement `XsdDoubleCodec` providing strict XSD 1.1 compliance for 64-bit floating point numbers.

Key changes:
- Support for lexical forms including decimal and scientific notation.
- Support for special values: `INF`, `+INF`, `-INF`, and `NaN`.
- Canonical mapping to scientific notation with exactly one non-zero digit before the decimal point.
- Strict whitespace collapse strategy.
- Added comprehensive unit tests and global facade entry.

Updates the README to reflect `xsd:double` implementation status.