### PR TITLE
feat(codec): implement xsd:int codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ We are incrementally implementing the RDF-compatible subset of XSD 1.1 types:
 | | `xsd:dayTimeDuration` | 🏗️ | `XsdDuration` |
 | **Limited-range Integers** | `xsd:byte` | ✅ | `XsdByte` |
 | | `xsd:short` | 🏗️ | `int` |
-| | `xsd:int` | 🏗️ | `int` |
+| | `xsd:int` | ✅ | `XsdInt` |
 | | `xsd:long` | 🏗️ | `int` / `BigInt` |
 | | `xsd:unsignedByte` | 🏗️ | `int` |
 | | `xsd:unsignedShort` | 🏗️ | `int` |

--- a/lib/src/codecs/byte.dart
+++ b/lib/src/codecs/byte.dart
@@ -14,7 +14,7 @@ extension type const XsdByte._(int value) implements int {
 
   /// Validates and creates an [XsdByte].
   ///
-  /// Throws an [ArgumentError] if the value is outside the range `[-128, 127]`.
+  /// Throws a [RangeError] if the value is outside the range `[-128, 127]`.
   factory XsdByte(int value) {
     if (value < min || value > max) {
       throw RangeError.range(value, min, max, 'XsdByte');

--- a/lib/src/codecs/byte.dart
+++ b/lib/src/codecs/byte.dart
@@ -6,12 +6,18 @@ import '../core/xsd_codec.dart';
 ///
 /// Value space: Integers in the range `[-128, 127]`.
 extension type const XsdByte._(int value) implements int {
+  /// The minimum value for an `xsd:byte`, equal to -128.
+  static const int min = -128;
+
+  /// The maximum value for an `xsd:byte`, equal to 127.
+  static const int max = 127;
+
   /// Validates and creates an [XsdByte].
   ///
   /// Throws an [ArgumentError] if the value is outside the range `[-128, 127]`.
   factory XsdByte(int value) {
-    if (value < -128 || value > 127) {
-      throw RangeError.range(value, -128, 127, 'XsdByte');
+    if (value < min || value > max) {
+      throw RangeError.range(value, min, max, 'XsdByte');
     }
     return XsdByte._(value);
   }
@@ -69,14 +75,13 @@ class XsdByteDecoder extends XsdConverter<String, XsdByte> {
 
     final value = int.parse(input);
 
-    if (value < -128 || value > 127) {
+    if (value < XsdByte.min || value > XsdByte.max) {
       throw XsdValidationException(
         'Value out of range for xsd:byte: $value',
         input: input,
         type: 'xsd:byte',
       );
     }
-
     return XsdByte.unsafe(value);
   }
 }

--- a/lib/src/codecs/byte.dart
+++ b/lib/src/codecs/byte.dart
@@ -73,15 +73,15 @@ class XsdByteDecoder extends XsdConverter<String, XsdByte> {
       );
     }
 
-    final value = int.parse(input);
+    final value = BigInt.parse(input);
 
-    if (value < XsdByte.min || value > XsdByte.max) {
+    if (value < BigInt.from(XsdByte.min) || value > BigInt.from(XsdByte.max)) {
       throw XsdValidationException(
         'Value out of range for xsd:byte: $value',
         input: input,
         type: 'xsd:byte',
       );
     }
-    return XsdByte.unsafe(value);
+    return XsdByte.unsafe(value.toInt());
   }
 }

--- a/lib/src/codecs/int.dart
+++ b/lib/src/codecs/int.dart
@@ -76,16 +76,13 @@ class XsdIntDecoder extends XsdConverter<String, XsdInt> {
 
     final value = int.parse(input);
 
-    try {
-      return XsdInt(value);
-      // In this particular case it does make sense to catch the RangeError
-      // ignore: avoid_catching_errors
-    } on RangeError catch (e) {
+    if (value < XsdInt.min || value > XsdInt.max) {
       throw XsdValidationException(
-        'Value out of range for xsd:int: ${e.invalidValue}',
+        'Value out of range for xsd:int: $value',
         input: input,
         type: 'xsd:int',
       );
     }
+    return XsdInt.unsafe(value);
   }
 }

--- a/lib/src/codecs/int.dart
+++ b/lib/src/codecs/int.dart
@@ -14,7 +14,7 @@ extension type const XsdInt._(int value) implements int {
 
   /// Validates and creates an [XsdInt].
   ///
-  /// Throws an [ArgumentError] if the value is outside the range
+  /// Throws a [RangeError] if the value is outside the range
   /// `[-2147483648, 2147483647]`.
   factory XsdInt(int value) {
     if (value < min || value > max) {

--- a/lib/src/codecs/int.dart
+++ b/lib/src/codecs/int.dart
@@ -1,0 +1,83 @@
+import '../core/exceptions.dart';
+import '../core/whitespace.dart';
+import '../core/xsd_codec.dart';
+
+/// Extension type on [int] representing the `xsd:int` value space.
+///
+/// Value space: Integers in the range `[-2147483648, 2147483647]`.
+extension type const XsdInt._(int value) implements int {
+  /// Validates and creates an [XsdInt].
+  ///
+  /// Throws an [ArgumentError] if the value is outside the range
+  /// `[-2147483648, 2147483647]`.
+  factory XsdInt(int value) {
+    if (value < -2147483648 || value > 2147483647) {
+      throw RangeError.range(value, -2147483648, 2147483647, 'XsdInt');
+    }
+    return XsdInt._(value);
+  }
+
+  /// Creates an [XsdInt] without validation.
+  const XsdInt.unsafe(this.value);
+}
+
+/// Codec for `xsd:int`.
+///
+/// According to XSD 1.1:
+/// - Value space: Integers in the range `[-2147483648, 2147483647]`.
+/// - Base type: `xsd:long`.
+/// - whiteSpace facet: collapse (fixed)
+/// - pattern: [\-+]?[0-9]+
+class XsdIntCodec extends XsdCodec<XsdInt> {
+  /// Creates a new [XsdIntCodec].
+  const XsdIntCodec();
+
+  @override
+  XsdWhitespace get whiteSpace => XsdWhitespace.collapse;
+
+  @override
+  XsdConverter<XsdInt, String> get encoder => const XsdIntEncoder();
+
+  @override
+  XsdConverter<String, XsdInt> get decoder => const XsdIntDecoder();
+}
+
+/// Encoder for `xsd:int`.
+class XsdIntEncoder extends XsdConverter<XsdInt, String> {
+  /// Creates a new [XsdIntEncoder].
+  const XsdIntEncoder();
+
+  @override
+  String convert(XsdInt input) => input.toString();
+}
+
+/// Decoder for `xsd:int`.
+class XsdIntDecoder extends XsdConverter<String, XsdInt> {
+  /// Creates a new [XsdIntDecoder].
+  const XsdIntDecoder();
+
+  static final RegExp _pattern = RegExp(r'^[\-+]?[0-9]+$');
+
+  @override
+  XsdInt convert(String input) {
+    if (!_pattern.hasMatch(input)) {
+      throw XsdValidationException(
+        'Invalid xsd:int lexical representation.',
+        input: input,
+        type: 'xsd:int',
+      );
+    }
+
+    final value = int.parse(input);
+
+    if (value < -2147483648 || value > 2147483647) {
+      throw XsdValidationException(
+        'Value out of range for xsd:int: $value',
+        input: input,
+        type: 'xsd:int',
+      );
+    }
+
+    return XsdInt.unsafe(value);
+  }
+}

--- a/lib/src/codecs/int.dart
+++ b/lib/src/codecs/int.dart
@@ -6,13 +6,19 @@ import '../core/xsd_codec.dart';
 ///
 /// Value space: Integers in the range `[-2147483648, 2147483647]`.
 extension type const XsdInt._(int value) implements int {
+  /// The minimum value for an `xsd:int`, equal to -2^31.
+  static const int min = -2147483648;
+
+  /// The maximum value for an `xsd:int`, equal to 2^31 - 1.
+  static const int max = 2147483647;
+
   /// Validates and creates an [XsdInt].
   ///
   /// Throws an [ArgumentError] if the value is outside the range
   /// `[-2147483648, 2147483647]`.
   factory XsdInt(int value) {
-    if (value < -2147483648 || value > 2147483647) {
-      throw RangeError.range(value, -2147483648, 2147483647, 'XsdInt');
+    if (value < min || value > max) {
+      throw RangeError.range(value, min, max, 'XsdInt');
     }
     return XsdInt._(value);
   }
@@ -70,14 +76,16 @@ class XsdIntDecoder extends XsdConverter<String, XsdInt> {
 
     final value = int.parse(input);
 
-    if (value < -2147483648 || value > 2147483647) {
+    try {
+      return XsdInt(value);
+      // In this particular case it does make sense to catch the RangeError
+      // ignore: avoid_catching_errors
+    } on RangeError catch (e) {
       throw XsdValidationException(
-        'Value out of range for xsd:int: $value',
+        'Value out of range for xsd:int: ${e.invalidValue}',
         input: input,
         type: 'xsd:int',
       );
     }
-
-    return XsdInt.unsafe(value);
   }
 }

--- a/lib/src/codecs/int.dart
+++ b/lib/src/codecs/int.dart
@@ -74,15 +74,15 @@ class XsdIntDecoder extends XsdConverter<String, XsdInt> {
       );
     }
 
-    final value = int.parse(input);
+    final value = BigInt.parse(input);
 
-    if (value < XsdInt.min || value > XsdInt.max) {
+    if (value < BigInt.from(XsdInt.min) || value > BigInt.from(XsdInt.max)) {
       throw XsdValidationException(
         'Value out of range for xsd:int: $value',
         input: input,
         type: 'xsd:int',
       );
     }
-    return XsdInt.unsafe(value);
+    return XsdInt.unsafe(value.toInt());
   }
 }

--- a/lib/src/core/facade.dart
+++ b/lib/src/core/facade.dart
@@ -2,6 +2,7 @@ import '../codecs/boolean.dart';
 import '../codecs/byte.dart';
 import '../codecs/decimal.dart';
 import '../codecs/double.dart';
+import '../codecs/int.dart';
 
 /// Global facade for XSD codecs.
 const xsd = XsdFacade._();
@@ -21,4 +22,7 @@ class XsdFacade {
 
   /// Codec for `xsd:double`.
   XsdDoubleCodec get double => const XsdDoubleCodec();
+
+  /// Codec for `xsd:int`.
+  XsdIntCodec get int => const XsdIntCodec();
 }

--- a/lib/xsd.dart
+++ b/lib/xsd.dart
@@ -7,6 +7,7 @@ export 'src/codecs/boolean.dart';
 export 'src/codecs/byte.dart';
 export 'src/codecs/decimal.dart';
 export 'src/codecs/double.dart';
+export 'src/codecs/int.dart';
 export 'src/core/exceptions.dart';
 export 'src/core/facade.dart';
 export 'src/core/xsd_codec.dart';

--- a/test/codecs/byte_test.dart
+++ b/test/codecs/byte_test.dart
@@ -73,6 +73,10 @@ void main() {
           () => codec.decode('-1000'),
           throwsA(isA<XsdValidationException>()),
         );
+        expect(
+          () => codec.decode('999999999999999999999'), // Exceeds 64-bit int
+          throwsA(isA<XsdValidationException>()),
+        );
       });
 
       test('throws XsdValidationException for invalid formats', () {

--- a/test/codecs/byte_test.dart
+++ b/test/codecs/byte_test.dart
@@ -15,6 +15,11 @@ void main() {
       const b = XsdByte.unsafe(1000); // Should not throw
       expect(b.value, 1000);
     });
+
+    test('static min/max methods', () {
+      expect(XsdByte.min, -128);
+      expect(XsdByte.max, 127);
+    });
   });
 
   group('XsdByteCodec', () {

--- a/test/codecs/int_test.dart
+++ b/test/codecs/int_test.dart
@@ -1,0 +1,75 @@
+import 'package:test/test.dart';
+import 'package:xsd/src/codecs/int.dart';
+import 'package:xsd/src/core/exceptions.dart';
+
+void main() {
+  group('XsdInt', () {
+    test('XsdInt() allows values in range [-2147483648, 2147483647]', () {
+      expect(XsdInt(-2147483648).value, equals(-2147483648));
+      expect(XsdInt(0).value, equals(0));
+      expect(XsdInt(2147483647).value, equals(2147483647));
+    });
+
+    test('XsdInt() throws RangeError for values out of range', () {
+      expect(() => XsdInt(-2147483649), throwsRangeError);
+      expect(() => XsdInt(2147483648), throwsRangeError);
+    });
+
+    test('XsdInt.unsafe() bypasses validation', () {
+      expect(XsdInt.unsafe(2147483648).value, equals(2147483648));
+    });
+  });
+
+  group('XsdIntCodec', () {
+    const codec = XsdIntCodec();
+
+    group('decode', () {
+      test('successfully decodes valid lexical forms', () {
+        expect(codec.decode('123'), equals(XsdInt(123)));
+        expect(codec.decode('+123'), equals(XsdInt(123)));
+        expect(codec.decode('-123'), equals(XsdInt(-123)));
+        expect(codec.decode('0'), equals(XsdInt(0)));
+        expect(codec.decode('000123'), equals(XsdInt(123)));
+        expect(
+          codec.decode(' 123 '),
+          equals(XsdInt(123)),
+        ); // Whitespace collapse
+      });
+
+      test('throws XsdValidationException for invalid lexical forms', () {
+        expect(() => codec.decode(''), throwsA(isA<XsdValidationException>()));
+        expect(
+          () => codec.decode('abc'),
+          throwsA(isA<XsdValidationException>()),
+        );
+        expect(
+          () => codec.decode('12.3'),
+          throwsA(isA<XsdValidationException>()),
+        );
+        expect(
+          () => codec.decode('++123'),
+          throwsA(isA<XsdValidationException>()),
+        );
+      });
+
+      test('throws XsdValidationException for out of range values', () {
+        expect(
+          () => codec.decode('2147483648'),
+          throwsA(isA<XsdValidationException>()),
+        );
+        expect(
+          () => codec.decode('-2147483649'),
+          throwsA(isA<XsdValidationException>()),
+        );
+      });
+    });
+
+    group('encode', () {
+      test('successfully encodes to canonical form', () {
+        expect(codec.encode(XsdInt(123)), equals('123'));
+        expect(codec.encode(XsdInt(-123)), equals('-123'));
+        expect(codec.encode(XsdInt(0)), equals('0'));
+      });
+    });
+  });
+}

--- a/test/codecs/int_test.dart
+++ b/test/codecs/int_test.dart
@@ -18,6 +18,11 @@ void main() {
     test('XsdInt.unsafe() bypasses validation', () {
       expect(XsdInt.unsafe(2147483648).value, equals(2147483648));
     });
+
+    test('static min/max methods', () {
+      expect(XsdInt.min, -2147483648);
+      expect(XsdInt.max, 2147483647);
+    });
   });
 
   group('XsdIntCodec', () {

--- a/test/codecs/int_test.dart
+++ b/test/codecs/int_test.dart
@@ -66,6 +66,10 @@ void main() {
           () => codec.decode('-2147483649'),
           throwsA(isA<XsdValidationException>()),
         );
+        expect(
+          () => codec.decode('999999999999999999999'), // Exceeds 64-bit int
+          throwsA(isA<XsdValidationException>()),
+        );
       });
     });
 


### PR DESCRIPTION
Implement `XsdIntCodec` providing strict XSD 1.1 compliance for 32-bit signed integers.

Key changes:
- Add `XsdInt` extension type for range-validated 32-bit integers.
- Support for lexical forms matching `[\-+]?[0-9]+`.
- Strict whitespace collapse strategy.
- Comprehensive unit tests for parsing, encoding, and range validation.
- Updated global `xsd` facade and library exports.
- Updated README status for `xsd:int`.