### PR TITLE
feat(codecs): implement xsd:integer codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ We are incrementally implementing the RDF-compatible subset of XSD 1.1 types:
 | **Core types** | `xsd:string` | 🏗️ | `String` |
 | | `xsd:boolean` | ✅ | `bool` |
 | | `xsd:decimal` | ✅ | `XsdDecimal` |
-| | `xsd:integer` | 🏗️ | `BigInt` |
+| | `xsd:integer` | ✅ | `XsdInteger` |
 | **IEEE Floating-Point** | `xsd:double` | ✅ | `double` |
 | | `xsd:float` | 🏗️ | `double` |
 | **Time and Date** | `xsd:date` | 🏗️ | `XsdDate` |

--- a/lib/src/codecs/integer.dart
+++ b/lib/src/codecs/integer.dart
@@ -1,0 +1,85 @@
+import '../core/exceptions.dart';
+import '../core/whitespace.dart';
+import '../core/xsd_codec.dart';
+
+/// Extension type on [BigInt] representing the `xsd:integer` value space.
+///
+/// Value space: Infinite set of integers ({..., -2, -1, 0, 1, 2, ...}).
+///
+/// This type ensures arbitrary precision and platform consistency by leveraging [BigInt].
+extension type const XsdInteger._(BigInt value) implements BigInt {
+  /// Creates an [XsdInteger].
+  const XsdInteger(this.value);
+
+  /// Creates an [XsdInteger] without validation (same as the main constructor).
+  const XsdInteger.unsafe(this.value);
+
+  /// Parses an [input] string into an [XsdInteger].
+  ///
+  /// The [input] must conform to the XSD 1.1 lexical representation:
+  /// `(\+|-)?([0-9]+)`
+  ///
+  /// Throws a [FormatException] if the [input] is not a valid integer.
+  factory XsdInteger.parse(String input) {
+    final regex = RegExp(r'^(\+|-)?([0-9]+)$');
+    if (!regex.hasMatch(input)) {
+      throw FormatException('Invalid xsd:integer lexical form: $input');
+    }
+
+    try {
+      return XsdInteger(BigInt.parse(input));
+    } on FormatException {
+      throw FormatException('Invalid xsd:integer lexical form: $input');
+    }
+  }
+}
+
+/// Codec for `xsd:integer`.
+///
+/// According to XSD 1.1:
+/// - Value space: Infinite set of integers.
+/// - Lexical representation: (\+|-)?([0-9]+)
+/// - whiteSpace facet: collapse (fixed)
+class XsdIntegerCodec extends XsdCodec<XsdInteger> {
+  /// Creates a new [XsdIntegerCodec].
+  const XsdIntegerCodec();
+
+  @override
+  XsdWhitespace get whiteSpace => XsdWhitespace.collapse;
+
+  @override
+  XsdConverter<XsdInteger, String> get encoder => const XsdIntegerEncoder();
+
+  @override
+  XsdConverter<String, XsdInteger> get decoder => const XsdIntegerDecoder();
+}
+
+/// Encoder for `xsd:integer`.
+class XsdIntegerEncoder extends XsdConverter<XsdInteger, String> {
+  /// Creates a new [XsdIntegerEncoder].
+  const XsdIntegerEncoder();
+
+  @override
+  String convert(XsdInteger input) {
+    return input.toString();
+  }
+}
+
+/// Decoder for `xsd:integer`.
+class XsdIntegerDecoder extends XsdConverter<String, XsdInteger> {
+  /// Creates a new [XsdIntegerDecoder].
+  const XsdIntegerDecoder();
+
+  @override
+  XsdInteger convert(String input) {
+    try {
+      return XsdInteger.parse(input);
+    } on FormatException catch (e) {
+      throw XsdValidationException(
+        e.message,
+        input: input,
+        type: 'xsd:integer',
+      );
+    }
+  }
+}

--- a/lib/src/core/facade.dart
+++ b/lib/src/core/facade.dart
@@ -3,6 +3,7 @@ import '../codecs/byte.dart';
 import '../codecs/decimal.dart';
 import '../codecs/double.dart';
 import '../codecs/int.dart';
+import '../codecs/integer.dart';
 
 /// Global facade for XSD codecs.
 const xsd = XsdFacade._();
@@ -25,4 +26,7 @@ class XsdFacade {
 
   /// Codec for `xsd:int`.
   XsdIntCodec get int => const XsdIntCodec();
+
+  /// Codec for `xsd:integer`.
+  XsdIntegerCodec get integer => const XsdIntegerCodec();
 }

--- a/lib/xsd.dart
+++ b/lib/xsd.dart
@@ -8,6 +8,7 @@ export 'src/codecs/byte.dart';
 export 'src/codecs/decimal.dart';
 export 'src/codecs/double.dart';
 export 'src/codecs/int.dart';
+export 'src/codecs/integer.dart';
 export 'src/core/exceptions.dart';
 export 'src/core/facade.dart';
 export 'src/core/xsd_codec.dart';

--- a/test/codecs/integer_test.dart
+++ b/test/codecs/integer_test.dart
@@ -65,6 +65,10 @@ void main() {
         () => decoder.convert(' '),
         throwsA(isA<XsdValidationException>()),
       );
+      expect(
+        () => decoder.convert('0x10'),
+        throwsA(isA<XsdValidationException>()),
+      );
     });
   });
 

--- a/test/codecs/integer_test.dart
+++ b/test/codecs/integer_test.dart
@@ -1,0 +1,86 @@
+import 'package:test/test.dart';
+import 'package:xsd/src/codecs/integer.dart';
+import 'package:xsd/src/core/exceptions.dart';
+import 'package:xsd/src/core/whitespace.dart';
+
+void main() {
+  group('XsdIntegerCodec', () {
+    const codec = XsdIntegerCodec();
+
+    test('metadata', () {
+      expect(codec.whiteSpace, equals(XsdWhitespace.collapse));
+      expect(codec.encoder, isA<XsdIntegerEncoder>());
+      expect(codec.decoder, isA<XsdIntegerDecoder>());
+    });
+
+    test('decode', () {
+      expect(codec.decode(' 123 '), equals(XsdInteger(BigInt.from(123))));
+    });
+
+    test('encode', () {
+      expect(codec.encode(XsdInteger(BigInt.from(123))), equals('123'));
+    });
+  });
+
+  group('XsdIntegerDecoder', () {
+    const decoder = XsdIntegerDecoder();
+
+    test('Valid lexical representations', () {
+      expect(decoder.convert('123'), equals(XsdInteger(BigInt.from(123))));
+      expect(decoder.convert('+123'), equals(XsdInteger(BigInt.from(123))));
+      expect(decoder.convert('-123'), equals(XsdInteger(BigInt.from(-123))));
+      expect(decoder.convert('0'), equals(XsdInteger(BigInt.zero)));
+      expect(decoder.convert('+0'), equals(XsdInteger(BigInt.zero)));
+      expect(decoder.convert('-0'), equals(XsdInteger(BigInt.zero)));
+      expect(decoder.convert('007'), equals(XsdInteger(BigInt.from(7))));
+      expect(
+        decoder.convert('123456789012345678901234567890'),
+        equals(XsdInteger(BigInt.parse('123456789012345678901234567890'))),
+      );
+    });
+
+    test('Invalid lexical representations', () {
+      expect(
+        () => decoder.convert('123.456'),
+        throwsA(isA<XsdValidationException>()),
+      );
+      expect(
+        () => decoder.convert('1E2'),
+        throwsA(isA<XsdValidationException>()),
+      );
+      expect(
+        () => decoder.convert('abc'),
+        throwsA(isA<XsdValidationException>()),
+      );
+      expect(() => decoder.convert(''), throwsA(isA<XsdValidationException>()));
+      expect(
+        () => decoder.convert('++1'),
+        throwsA(isA<XsdValidationException>()),
+      );
+      expect(
+        () => decoder.convert('+-1'),
+        throwsA(isA<XsdValidationException>()),
+      );
+      expect(
+        () => decoder.convert(' '),
+        throwsA(isA<XsdValidationException>()),
+      );
+    });
+  });
+
+  group('XsdIntegerEncoder', () {
+    const encoder = XsdIntegerEncoder();
+
+    test('Canonical lexical mapping', () {
+      expect(encoder.convert(XsdInteger(BigInt.from(123))), equals('123'));
+      expect(encoder.convert(XsdInteger(BigInt.from(-123))), equals('-123'));
+      expect(encoder.convert(XsdInteger(BigInt.zero)), equals('0'));
+      expect(
+        encoder.convert(
+          XsdInteger(BigInt.parse('123456789012345678901234567890')),
+        ),
+        equals('123456789012345678901234567890'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
- Add `XsdInteger` extension type as a wrapper for `BigInt`.
- Implement `XsdIntegerCodec` with support for XSD 1.1 compliant lexical forms.
- Register `integer` in the `xsd` facade and export from `lib/xsd.dart`.
- Add comprehensive unit tests for parsing, encoding, and whitespace handling.
- Update `README.md` status for `xsd:integer`.