### PR TITLE
feat(codecs): implement xsd:long codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We are incrementally implementing the RDF-compatible subset of XSD 1.1 types:
 | **Limited-range Integers** | `xsd:byte` | ✅ | `XsdByte` |
 | | `xsd:short` | 🏗️ | `int` |
 | | `xsd:int` | ✅ | `XsdInt` |
-| | `xsd:long` | 🏗️ | `int` / `BigInt` |
+| | `xsd:long` | ✅ | `XsdLong` / `BigInt` |
 | | `xsd:unsignedByte` | 🏗️ | `int` |
 | | `xsd:unsignedShort` | 🏗️ | `int` |
 | | `xsd:unsignedInt` | 🏗️ | `int` |

--- a/lib/src/codecs/long.dart
+++ b/lib/src/codecs/long.dart
@@ -1,0 +1,92 @@
+import '../core/exceptions.dart';
+import '../core/whitespace.dart';
+import '../core/xsd_codec.dart';
+
+/// Extension type on [BigInt] representing the `xsd:long` value space.
+///
+/// Value space: Integers in the range `[-9223372036854775808, 9223372036854775807]`.
+extension type const XsdLong._(BigInt value) implements BigInt {
+  /// The minimum value for an [XsdLong].
+  static final BigInt min = BigInt.parse('-9223372036854775808');
+
+  /// The maximum value for an [XsdLong].
+  static final BigInt max = BigInt.parse('9223372036854775807');
+
+  /// Validates and creates an [XsdLong].
+  ///
+  /// Throws an [ArgumentError] if the value is outside the range
+  /// `[-9223372036854775808, 9223372036854775807]`.
+  factory XsdLong(BigInt value) {
+    if (value < min || value > max) {
+      throw ArgumentError(
+        'Value out of range for XsdLong: $value. '
+        'Must be between $min and $max.',
+      );
+    }
+    return XsdLong._(value);
+  }
+
+  /// Creates an [XsdLong] without validation.
+  const XsdLong.unsafe(this.value);
+}
+
+/// Codec for `xsd:long`.
+///
+/// According to XSD 1.1:
+/// - Value space: Integers in the range `[-9223372036854775808, 9223372036854775807]`.
+/// - Base type: `xsd:integer`.
+/// - whiteSpace facet: collapse (fixed)
+/// - pattern: [\-+]?[0-9]+
+class XsdLongCodec extends XsdCodec<XsdLong> {
+  /// Creates a new [XsdLongCodec].
+  const XsdLongCodec();
+
+  @override
+  XsdWhitespace get whiteSpace => XsdWhitespace.collapse;
+
+  @override
+  XsdConverter<XsdLong, String> get encoder => const XsdLongEncoder();
+
+  @override
+  XsdConverter<String, XsdLong> get decoder => const XsdLongDecoder();
+}
+
+/// Encoder for `xsd:long`.
+class XsdLongEncoder extends XsdConverter<XsdLong, String> {
+  /// Creates a new [XsdLongEncoder].
+  const XsdLongEncoder();
+
+  @override
+  String convert(XsdLong input) => input.toString();
+}
+
+/// Decoder for `xsd:long`.
+class XsdLongDecoder extends XsdConverter<String, XsdLong> {
+  /// Creates a new [XsdLongDecoder].
+  const XsdLongDecoder();
+
+  static final RegExp _pattern = RegExp(r'^[\-+]?[0-9]+$');
+
+  @override
+  XsdLong convert(String input) {
+    if (!_pattern.hasMatch(input)) {
+      throw XsdValidationException(
+        'Invalid xsd:long lexical representation.',
+        input: input,
+        type: 'xsd:long',
+      );
+    }
+
+    final value = BigInt.parse(input);
+
+    if (value < XsdLong.min || value > XsdLong.max) {
+      throw XsdValidationException(
+        'Value out of range for xsd:long: $value',
+        input: input,
+        type: 'xsd:long',
+      );
+    }
+
+    return XsdLong.unsafe(value);
+  }
+}

--- a/lib/src/core/facade.dart
+++ b/lib/src/core/facade.dart
@@ -4,6 +4,7 @@ import '../codecs/decimal.dart';
 import '../codecs/double.dart';
 import '../codecs/int.dart';
 import '../codecs/integer.dart';
+import '../codecs/long.dart';
 
 /// Global facade for XSD codecs.
 const xsd = XsdFacade._();
@@ -29,4 +30,7 @@ class XsdFacade {
 
   /// Codec for `xsd:integer`.
   XsdIntegerCodec get integer => const XsdIntegerCodec();
+
+  /// Codec for `xsd:long`.
+  XsdLongCodec get long => const XsdLongCodec();
 }

--- a/lib/xsd.dart
+++ b/lib/xsd.dart
@@ -9,6 +9,7 @@ export 'src/codecs/decimal.dart';
 export 'src/codecs/double.dart';
 export 'src/codecs/int.dart';
 export 'src/codecs/integer.dart';
+export 'src/codecs/long.dart';
 export 'src/core/exceptions.dart';
 export 'src/core/facade.dart';
 export 'src/core/xsd_codec.dart';

--- a/test/codecs/long_test.dart
+++ b/test/codecs/long_test.dart
@@ -1,0 +1,103 @@
+import 'package:test/test.dart';
+import 'package:xsd/src/codecs/long.dart';
+import 'package:xsd/src/core/exceptions.dart';
+import 'package:xsd/src/core/whitespace.dart';
+
+void main() {
+  group('XsdLong', () {
+    test(
+      'XsdLong() allows values in range [-9223372036854775808, 9223372036854775807]',
+      () {
+        final min = BigInt.parse('-9223372036854775808');
+        final max = BigInt.parse('9223372036854775807');
+
+        expect(XsdLong(min).value, equals(min));
+        expect(XsdLong(BigInt.zero).value, equals(BigInt.zero));
+        expect(XsdLong(max).value, equals(max));
+      },
+    );
+
+    test('XsdLong() throws ArgumentError for values out of range', () {
+      final belowMin = BigInt.parse('-9223372036854775809');
+      final aboveMax = BigInt.parse('9223372036854775808');
+
+      expect(() => XsdLong(belowMin), throwsArgumentError);
+      expect(() => XsdLong(aboveMax), throwsArgumentError);
+    });
+
+    test('XsdLong.unsafe() bypasses validation', () {
+      final aboveMax = BigInt.parse('9223372036854775808');
+      expect(XsdLong.unsafe(aboveMax).value, equals(aboveMax));
+    });
+  });
+
+  group('XsdLongEncoder', () {
+    const encoder = XsdLongEncoder();
+
+    test('successfully encodes to canonical form', () {
+      expect(encoder.convert(XsdLong(BigInt.from(123))), equals('123'));
+      expect(encoder.convert(XsdLong(BigInt.from(-123))), equals('-123'));
+      expect(encoder.convert(XsdLong(BigInt.zero)), equals('0'));
+      expect(
+        encoder.convert(XsdLong(BigInt.parse('9223372036854775807'))),
+        equals('9223372036854775807'),
+      );
+    });
+  });
+
+  group('XsdLongDecoder', () {
+    const decoder = XsdLongDecoder();
+
+    test('successfully decodes valid lexical forms', () {
+      expect(decoder.convert('123'), equals(XsdLong(BigInt.from(123))));
+      expect(decoder.convert('+123'), equals(XsdLong(BigInt.from(123))));
+      expect(decoder.convert('-123'), equals(XsdLong(BigInt.from(-123))));
+      expect(decoder.convert('0'), equals(XsdLong(BigInt.zero)));
+      expect(decoder.convert('000123'), equals(XsdLong(BigInt.from(123))));
+    });
+
+    test('throws XsdValidationException for invalid lexical forms', () {
+      expect(() => decoder.convert(''), throwsA(isA<XsdValidationException>()));
+      expect(
+        () => decoder.convert('abc'),
+        throwsA(isA<XsdValidationException>()),
+      );
+      expect(
+        () => decoder.convert('12.3'),
+        throwsA(isA<XsdValidationException>()),
+      );
+      expect(
+        () => decoder.convert('++123'),
+        throwsA(isA<XsdValidationException>()),
+      );
+    });
+
+    test('throws XsdValidationException for out of range values', () {
+      expect(
+        () => decoder.convert('9223372036854775808'),
+        throwsA(isA<XsdValidationException>()),
+      );
+      expect(
+        () => decoder.convert('-9223372036854775809'),
+        throwsA(isA<XsdValidationException>()),
+      );
+    });
+  });
+
+  group('XsdLongCodec', () {
+    const codec = XsdLongCodec();
+
+    test('has correct whiteSpace facet', () {
+      expect(codec.whiteSpace, equals(XsdWhitespace.collapse));
+    });
+
+    test('decode collapses whitespace', () {
+      expect(codec.decode(' 123 '), equals(XsdLong(BigInt.from(123))));
+    });
+
+    test('encode/decode symmetry', () {
+      final value = XsdLong(BigInt.from(123456));
+      expect(codec.decode(codec.encode(value)), equals(value));
+    });
+  });
+}


### PR DESCRIPTION
- Add `XsdLong` extension type on `BigInt` for 64-bit signed integers.
- Implement `XsdLongCodec`, `XsdLongEncoder`, and `XsdLongDecoder`.
- Add range validation for `[-9223372036854775808, 9223372036854775807]`.
- Register `long` in the `xsd` facade and export from `lib/xsd.dart`.
- Add comprehensive unit tests in `test/codecs/long_test.dart`.
- Update `README.md` status for `xsd:long`.