### PR TITLE
feat(codecs): implement xsd:negativeInteger codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ We are incrementally implementing the RDF-compatible subset of XSD 1.1 types:
 | | `xsd:unsignedLong` | 🏗️ | `BigInt` |
 | | `xsd:positiveInteger` | 🏗️ | `BigInt` |
 | | `xsd:nonNegativeInteger` | 🏗️ | `BigInt` |
-| | `xsd:negativeInteger` | 🏗️ | `BigInt` |
+| | `xsd:negativeInteger` | ✅ | `XsdNegativeInteger` / `BigInt` |
 | | `xsd:nonPositiveInteger` | 🏗️ | `BigInt` |
 | **Encoded Binary** | `xsd:hexBinary` | 🏗️ | `Uint8List` |
 | | `xsd:base64Binary` | 🏗️ | `Uint8List` |

--- a/lib/src/codecs/negative_integer.dart
+++ b/lib/src/codecs/negative_integer.dart
@@ -1,0 +1,102 @@
+import '../core/exceptions.dart';
+import '../core/whitespace.dart';
+import '../core/xsd_codec.dart';
+
+/// Extension type on [BigInt] representing the `xsd:negativeInteger` value space.
+///
+/// Value space: Integers strictly less than zero ({..., -2, -1}).
+///
+/// This type ensures arbitrary precision and platform consistency by leveraging [BigInt].
+extension type const XsdNegativeInteger._(BigInt value) implements BigInt {
+  /// Validates and creates an [XsdNegativeInteger].
+  ///
+  /// Throws an [ArgumentError] if the [value] is greater than or equal to zero.
+  factory XsdNegativeInteger(BigInt value) {
+    if (value >= BigInt.zero) {
+      throw ArgumentError(
+        'Value out of range for XsdNegativeInteger: $value. '
+        'Must be strictly less than 0.',
+      );
+    }
+    return XsdNegativeInteger._(value);
+  }
+
+  /// Creates an [XsdNegativeInteger] without validation.
+  const XsdNegativeInteger.unsafe(this.value);
+
+  /// Parses an [input] string into an [XsdNegativeInteger].
+  ///
+  /// The [input] must conform to the XSD 1.1 lexical representation:
+  /// `[\-+]?[0-9]+`
+  ///
+  /// Throws a [FormatException] if the [input] is not a valid negative integer.
+  factory XsdNegativeInteger.parse(String input) {
+    final regex = RegExp(r'^[\-+]?[0-9]+$');
+    if (!regex.hasMatch(input)) {
+      throw FormatException('Invalid xsd:negativeInteger lexical form: $input');
+    }
+
+    final value = BigInt.parse(input);
+
+    if (value >= BigInt.zero) {
+      throw FormatException(
+        'Value out of range for xsd:negativeInteger: $value',
+      );
+    }
+
+    return XsdNegativeInteger._(value);
+  }
+}
+
+/// Codec for `xsd:negativeInteger`.
+///
+/// According to XSD 1.1:
+/// - Value space: Integers < 0.
+/// - Base type: `xsd:nonPositiveInteger`.
+/// - whiteSpace facet: collapse (fixed)
+/// - pattern: [\-+]?[0-9]+
+class XsdNegativeIntegerCodec extends XsdCodec<XsdNegativeInteger> {
+  /// Creates a new [XsdNegativeIntegerCodec].
+  const XsdNegativeIntegerCodec();
+
+  @override
+  XsdWhitespace get whiteSpace => XsdWhitespace.collapse;
+
+  @override
+  XsdConverter<XsdNegativeInteger, String> get encoder =>
+      const XsdNegativeIntegerEncoder();
+
+  @override
+  XsdConverter<String, XsdNegativeInteger> get decoder =>
+      const XsdNegativeIntegerDecoder();
+}
+
+/// Encoder for `xsd:negativeInteger`.
+class XsdNegativeIntegerEncoder
+    extends XsdConverter<XsdNegativeInteger, String> {
+  /// Creates a new [XsdNegativeIntegerEncoder].
+  const XsdNegativeIntegerEncoder();
+
+  @override
+  String convert(XsdNegativeInteger input) => input.toString();
+}
+
+/// Decoder for `xsd:negativeInteger`.
+class XsdNegativeIntegerDecoder
+    extends XsdConverter<String, XsdNegativeInteger> {
+  /// Creates a new [XsdNegativeIntegerDecoder].
+  const XsdNegativeIntegerDecoder();
+
+  @override
+  XsdNegativeInteger convert(String input) {
+    try {
+      return XsdNegativeInteger.parse(input);
+    } on FormatException catch (e) {
+      throw XsdValidationException(
+        e.message,
+        input: input,
+        type: 'xsd:negativeInteger',
+      );
+    }
+  }
+}

--- a/lib/src/codecs/negative_integer.dart
+++ b/lib/src/codecs/negative_integer.dart
@@ -8,6 +8,8 @@ import '../core/xsd_codec.dart';
 ///
 /// This type ensures arbitrary precision and platform consistency by leveraging [BigInt].
 extension type const XsdNegativeInteger._(BigInt value) implements BigInt {
+  static final _regex = RegExp(r'^[-+]?[0-9]+$');
+
   /// Validates and creates an [XsdNegativeInteger].
   ///
   /// Throws an [ArgumentError] if the [value] is greater than or equal to zero.
@@ -31,8 +33,7 @@ extension type const XsdNegativeInteger._(BigInt value) implements BigInt {
   ///
   /// Throws a [FormatException] if the [input] is not a valid negative integer.
   factory XsdNegativeInteger.parse(String input) {
-    final regex = RegExp(r'^[\-+]?[0-9]+$');
-    if (!regex.hasMatch(input)) {
+    if (!_regex.hasMatch(input)) {
       throw FormatException('Invalid xsd:negativeInteger lexical form: $input');
     }
 

--- a/lib/src/core/facade.dart
+++ b/lib/src/core/facade.dart
@@ -5,6 +5,7 @@ import '../codecs/double.dart';
 import '../codecs/int.dart';
 import '../codecs/integer.dart';
 import '../codecs/long.dart';
+import '../codecs/negative_integer.dart';
 
 /// Global facade for XSD codecs.
 const xsd = XsdFacade._();
@@ -33,4 +34,8 @@ class XsdFacade {
 
   /// Codec for `xsd:long`.
   XsdLongCodec get long => const XsdLongCodec();
+
+  /// Codec for `xsd:negativeInteger`.
+  XsdNegativeIntegerCodec get negativeInteger =>
+      const XsdNegativeIntegerCodec();
 }

--- a/lib/xsd.dart
+++ b/lib/xsd.dart
@@ -10,6 +10,7 @@ export 'src/codecs/double.dart';
 export 'src/codecs/int.dart';
 export 'src/codecs/integer.dart';
 export 'src/codecs/long.dart';
+export 'src/codecs/negative_integer.dart';
 export 'src/core/exceptions.dart';
 export 'src/core/facade.dart';
 export 'src/core/xsd_codec.dart';

--- a/test/codecs/negative_integer_test.dart
+++ b/test/codecs/negative_integer_test.dart
@@ -1,0 +1,89 @@
+import 'package:test/test.dart';
+import 'package:xsd/src/codecs/negative_integer.dart';
+import 'package:xsd/src/core/exceptions.dart';
+
+void main() {
+  group('XsdNegativeInteger', () {
+    test('should allow negative integers', () {
+      final value = XsdNegativeInteger(BigInt.from(-100));
+      expect(value, equals(BigInt.from(-100)));
+    });
+
+    test('should throw ArgumentError for zero', () {
+      expect(() => XsdNegativeInteger(BigInt.zero), throwsArgumentError);
+    });
+
+    test('should throw ArgumentError for positive integers', () {
+      expect(() => XsdNegativeInteger(BigInt.from(1)), throwsArgumentError);
+    });
+
+    test('unsafe constructor should not validate', () {
+      final value = XsdNegativeInteger.unsafe(BigInt.from(0));
+      expect(value, equals(BigInt.zero));
+    });
+
+    group('parse', () {
+      test('should parse valid negative integers', () {
+        expect(XsdNegativeInteger.parse('-1'), equals(BigInt.from(-1)));
+        expect(XsdNegativeInteger.parse('-01'), equals(BigInt.from(-1)));
+        expect(
+          XsdNegativeInteger.parse('-12345678901234567890'),
+          equals(BigInt.parse('-12345678901234567890')),
+        );
+      });
+
+      test('should throw FormatException for zero', () {
+        expect(() => XsdNegativeInteger.parse('0'), throwsFormatException);
+        expect(() => XsdNegativeInteger.parse('+0'), throwsFormatException);
+        expect(() => XsdNegativeInteger.parse('-0'), throwsFormatException);
+      });
+
+      test('should throw FormatException for positive integers', () {
+        expect(() => XsdNegativeInteger.parse('1'), throwsFormatException);
+        expect(() => XsdNegativeInteger.parse('+1'), throwsFormatException);
+      });
+
+      test('should throw FormatException for invalid lexical forms', () {
+        expect(() => XsdNegativeInteger.parse(''), throwsFormatException);
+        expect(() => XsdNegativeInteger.parse('abc'), throwsFormatException);
+        expect(() => XsdNegativeInteger.parse('-1.0'), throwsFormatException);
+      });
+    });
+
+    group('XsdNegativeIntegerCodec', () {
+      const codec = XsdNegativeIntegerCodec();
+
+      test('decoder should parse valid strings', () {
+        expect(codec.decode('-1'), equals(BigInt.from(-1)));
+        expect(codec.decode('-123'), equals(BigInt.from(-123)));
+        expect(codec.decode('  -456  '), equals(BigInt.from(-456))); // collapse
+      });
+
+      test(
+        'decoder should throw XsdValidationException for invalid strings',
+        () {
+          expect(
+            () => codec.decode('0'),
+            throwsA(isA<XsdValidationException>()),
+          );
+          expect(
+            () => codec.decode('1'),
+            throwsA(isA<XsdValidationException>()),
+          );
+          expect(
+            () => codec.decode('abc'),
+            throwsA(isA<XsdValidationException>()),
+          );
+        },
+      );
+
+      test('encoder should produce canonical strings', () {
+        expect(codec.encode(XsdNegativeInteger(BigInt.from(-1))), equals('-1'));
+        expect(
+          codec.encode(XsdNegativeInteger(BigInt.from(-100))),
+          equals('-100'),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
- Add `XsdNegativeInteger` extension type for arbitrary-precision negative integers.
- Implement `XsdNegativeIntegerCodec` following XSD 1.1 specifications.
- Register `negativeInteger` in the `xsd` facade and export from `lib/xsd.dart`.
- Update `README.md` to reflect `xsd:negativeInteger` as implemented.
- Add comprehensive tests in `test/codecs/negative_integer_test.dart`.