### PR TITLE
feat(codecs): implement xsd:nonPositiveInteger codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ We are incrementally implementing the RDF-compatible subset of XSD 1.1 types:
 | | `xsd:positiveInteger` | 🏗️ | `BigInt` |
 | | `xsd:nonNegativeInteger` | ✅ | `XsdNonNegativeInteger` / `BigInt` |
 | | `xsd:negativeInteger` | ✅ | `XsdNegativeInteger` / `BigInt` |
-| | `xsd:nonPositiveInteger` | 🏗️ | `BigInt` |
+| | `xsd:nonPositiveInteger` | ✅ | `XsdNonPositiveInteger` / `BigInt` |
 | **Encoded Binary** | `xsd:hexBinary` | 🏗️ | `Uint8List` |
 | | `xsd:base64Binary` | 🏗️ | `Uint8List` |
 | **Miscellaneous** | `xsd:anyURI` | 🏗️ | `Uri` |

--- a/lib/src/codecs/non_positive_integer.dart
+++ b/lib/src/codecs/non_positive_integer.dart
@@ -8,6 +8,8 @@ import '../core/xsd_codec.dart';
 ///
 /// This type ensures arbitrary precision and platform consistency by leveraging [BigInt].
 extension type const XsdNonPositiveInteger._(BigInt value) implements BigInt {
+  static final _regex = RegExp(r'^[\-+]?[0-9]+$');
+
   /// Validates and creates an [XsdNonPositiveInteger].
   ///
   /// Throws an [ArgumentError] if the [value] is positive.
@@ -34,8 +36,7 @@ extension type const XsdNonPositiveInteger._(BigInt value) implements BigInt {
   ///
   /// Throws a [FormatException] if the [input] is not a valid non-positive integer.
   factory XsdNonPositiveInteger.parse(String input) {
-    final regex = RegExp(r'^[\-+]?[0-9]+$');
-    if (!regex.hasMatch(input)) {
+    if (!_regex.hasMatch(input)) {
       throw FormatException(
         'Invalid xsd:nonPositiveInteger lexical form: $input',
       );

--- a/lib/src/codecs/non_positive_integer.dart
+++ b/lib/src/codecs/non_positive_integer.dart
@@ -1,0 +1,113 @@
+import '../core/exceptions.dart';
+import '../core/whitespace.dart';
+import '../core/xsd_codec.dart';
+
+/// Extension type on [BigInt] representing the `xsd:nonPositiveInteger` value space.
+///
+/// Value space: Integers less than or equal to zero ({..., -2, -1, 0}).
+///
+/// This type ensures arbitrary precision and platform consistency by leveraging [BigInt].
+extension type const XsdNonPositiveInteger._(BigInt value) implements BigInt {
+  /// Validates and creates an [XsdNonPositiveInteger].
+  ///
+  /// Throws an [ArgumentError] if the [value] is positive.
+  factory XsdNonPositiveInteger(BigInt value) {
+    if (value > BigInt.zero) {
+      throw ArgumentError(
+        'Value out of range for XsdNonPositiveInteger: $value. '
+        'Must be less than or equal to 0.',
+      );
+    }
+    return XsdNonPositiveInteger._(value);
+  }
+
+  /// Creates an [XsdNonPositiveInteger] without validation.
+  const XsdNonPositiveInteger.unsafe(this.value);
+
+  /// Parses an [input] string into an [XsdNonPositiveInteger].
+  ///
+  /// The [input] must conform to the XSD 1.1 lexical representation:
+  /// `[\-+]?[0-9]+`
+  ///
+  /// For zero, the sign can be '+' or omitted.
+  /// For all other values, the negative sign ('-') must be present.
+  ///
+  /// Throws a [FormatException] if the [input] is not a valid non-positive integer.
+  factory XsdNonPositiveInteger.parse(String input) {
+    final regex = RegExp(r'^[\-+]?[0-9]+$');
+    if (!regex.hasMatch(input)) {
+      throw FormatException(
+        'Invalid xsd:nonPositiveInteger lexical form: $input',
+      );
+    }
+
+    final value = BigInt.parse(input);
+
+    if (value > BigInt.zero) {
+      throw FormatException(
+        'Value out of range for xsd:nonPositiveInteger: $value',
+      );
+    }
+
+    if (value < BigInt.zero && !input.startsWith('-')) {
+      throw FormatException(
+        'Non-zero negative values must have a negative sign: $input',
+      );
+    }
+
+    return XsdNonPositiveInteger._(value);
+  }
+}
+
+/// Codec for `xsd:nonPositiveInteger`.
+///
+/// According to XSD 1.1:
+/// - Value space: Integers <= 0.
+/// - Base type: `xsd:integer`.
+/// - whiteSpace facet: collapse (fixed)
+/// - pattern: [\-+]?[0-9]+
+class XsdNonPositiveIntegerCodec extends XsdCodec<XsdNonPositiveInteger> {
+  /// Creates a new [XsdNonPositiveIntegerCodec].
+  const XsdNonPositiveIntegerCodec();
+
+  @override
+  XsdWhitespace get whiteSpace => XsdWhitespace.collapse;
+
+  @override
+  XsdConverter<XsdNonPositiveInteger, String> get encoder =>
+      const XsdNonPositiveIntegerEncoder();
+
+  @override
+  XsdConverter<String, XsdNonPositiveInteger> get decoder =>
+      const XsdNonPositiveIntegerDecoder();
+}
+
+/// Encoder for `xsd:nonPositiveInteger`.
+class XsdNonPositiveIntegerEncoder
+    extends XsdConverter<XsdNonPositiveInteger, String> {
+  /// Creates a new [XsdNonPositiveIntegerEncoder].
+  const XsdNonPositiveIntegerEncoder();
+
+  @override
+  String convert(XsdNonPositiveInteger input) => input.toString();
+}
+
+/// Decoder for `xsd:nonPositiveInteger`.
+class XsdNonPositiveIntegerDecoder
+    extends XsdConverter<String, XsdNonPositiveInteger> {
+  /// Creates a new [XsdNonPositiveIntegerDecoder].
+  const XsdNonPositiveIntegerDecoder();
+
+  @override
+  XsdNonPositiveInteger convert(String input) {
+    try {
+      return XsdNonPositiveInteger.parse(input);
+    } on FormatException catch (e) {
+      throw XsdValidationException(
+        e.message,
+        input: input,
+        type: 'xsd:nonPositiveInteger',
+      );
+    }
+  }
+}

--- a/lib/src/core/facade.dart
+++ b/lib/src/core/facade.dart
@@ -7,6 +7,7 @@ import '../codecs/integer.dart';
 import '../codecs/long.dart';
 import '../codecs/negative_integer.dart';
 import '../codecs/non_negative_integer.dart';
+import '../codecs/non_positive_integer.dart';
 
 /// Global facade for XSD codecs.
 const xsd = XsdFacade._();
@@ -43,4 +44,8 @@ class XsdFacade {
   /// Codec for `xsd:nonNegativeInteger`.
   XsdNonNegativeIntegerCodec get nonNegativeInteger =>
       const XsdNonNegativeIntegerCodec();
+
+  /// Codec for `xsd:nonPositiveInteger`.
+  XsdNonPositiveIntegerCodec get nonPositiveInteger =>
+      const XsdNonPositiveIntegerCodec();
 }

--- a/lib/xsd.dart
+++ b/lib/xsd.dart
@@ -12,6 +12,7 @@ export 'src/codecs/integer.dart';
 export 'src/codecs/long.dart';
 export 'src/codecs/negative_integer.dart';
 export 'src/codecs/non_negative_integer.dart';
+export 'src/codecs/non_positive_integer.dart';
 export 'src/core/exceptions.dart';
 export 'src/core/facade.dart';
 export 'src/core/xsd_codec.dart';

--- a/test/codecs/non_positive_integer_test.dart
+++ b/test/codecs/non_positive_integer_test.dart
@@ -1,0 +1,110 @@
+import 'package:test/test.dart';
+import 'package:xsd/src/codecs/non_positive_integer.dart';
+import 'package:xsd/src/core/exceptions.dart';
+
+void main() {
+  group('XsdNonPositiveInteger', () {
+    test('should allow zero', () {
+      final value = XsdNonPositiveInteger(BigInt.zero);
+      expect(value, equals(BigInt.zero));
+    });
+
+    test('should allow negative integers', () {
+      final value = XsdNonPositiveInteger(BigInt.from(-100));
+      expect(value, equals(BigInt.from(-100)));
+    });
+
+    test('should throw ArgumentError for positive integers', () {
+      expect(() => XsdNonPositiveInteger(BigInt.one), throwsArgumentError);
+      expect(
+        () => XsdNonPositiveInteger(BigInt.from(123)),
+        throwsArgumentError,
+      );
+    });
+
+    test('unsafe constructor should not validate', () {
+      final value = XsdNonPositiveInteger.unsafe(BigInt.one);
+      expect(value, equals(BigInt.one));
+    });
+
+    group('parse', () {
+      test('should parse valid zero strings', () {
+        expect(XsdNonPositiveInteger.parse('0'), equals(BigInt.zero));
+        expect(XsdNonPositiveInteger.parse('+0'), equals(BigInt.zero));
+        expect(XsdNonPositiveInteger.parse('-0'), equals(BigInt.zero));
+        expect(XsdNonPositiveInteger.parse('000'), equals(BigInt.zero));
+        expect(XsdNonPositiveInteger.parse('+00'), equals(BigInt.zero));
+      });
+
+      test('should parse valid negative integers', () {
+        expect(XsdNonPositiveInteger.parse('-1'), equals(BigInt.from(-1)));
+        expect(XsdNonPositiveInteger.parse('-01'), equals(BigInt.from(-1)));
+        expect(
+          XsdNonPositiveInteger.parse('-12345678901234567890'),
+          equals(BigInt.parse('-12345678901234567890')),
+        );
+      });
+
+      test('should throw FormatException for positive integers', () {
+        expect(() => XsdNonPositiveInteger.parse('1'), throwsFormatException);
+        expect(() => XsdNonPositiveInteger.parse('+1'), throwsFormatException);
+      });
+
+      test('should throw FormatException for invalid lexical forms', () {
+        expect(() => XsdNonPositiveInteger.parse(''), throwsFormatException);
+        expect(() => XsdNonPositiveInteger.parse('abc'), throwsFormatException);
+        expect(() => XsdNonPositiveInteger.parse('1.0'), throwsFormatException);
+        expect(() => XsdNonPositiveInteger.parse('1E0'), throwsFormatException);
+      });
+
+      test('should throw FormatException for non-zero without negative sign', () {
+        // According to XSD spec: "the negative sign ('-') must be present" for non-zero values.
+        // Actually, the spec says: "The sign may be '+' or may be omitted only for lexical forms denoting zero;
+        // in all other lexical forms, the negative sign ('-') must be present."
+        expect(() => XsdNonPositiveInteger.parse('1'), throwsFormatException);
+        expect(() => XsdNonPositiveInteger.parse('+1'), throwsFormatException);
+      });
+    });
+
+    group('XsdNonPositiveIntegerCodec', () {
+      const codec = XsdNonPositiveIntegerCodec();
+
+      test('decoder should parse valid strings', () {
+        expect(codec.decode('0'), equals(BigInt.zero));
+        expect(codec.decode('-123'), equals(BigInt.from(-123)));
+      });
+
+      test(
+        'decoder should throw XsdValidationException for invalid strings',
+        () {
+          expect(
+            () => codec.decode('1'),
+            throwsA(isA<XsdValidationException>()),
+          );
+          expect(
+            () => codec.decode('abc'),
+            throwsA(isA<XsdValidationException>()),
+          );
+        },
+      );
+
+      test('encoder should produce canonical strings', () {
+        expect(codec.encode(XsdNonPositiveInteger(BigInt.zero)), equals('0'));
+        expect(
+          codec.encode(XsdNonPositiveInteger(BigInt.from(-1))),
+          equals('-1'),
+        );
+        expect(
+          codec.encode(XsdNonPositiveInteger(BigInt.from(-100))),
+          equals('-100'),
+        );
+        expect(
+          codec.encode(
+            XsdNonPositiveInteger(BigInt.parse('-12345678901234567890')),
+          ),
+          equals('-12345678901234567890'),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
- Add `XsdNonPositiveInteger` extension type for arbitrary-precision non-positive integers.
- Implement `XsdNonPositiveIntegerCodec` following XSD 1.1 specifications.
- Register `nonPositiveInteger` in the `xsd` facade and export from `lib/xsd.dart`.
- Update `README.md` to reflect `xsd:nonPositiveInteger` as implemented.
- Add comprehensive tests in `test/codecs/non_positive_integer_test.dart`.