### PR TITLE
feat(codecs): implement xsd:positiveInteger codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ We are incrementally implementing the RDF-compatible subset of XSD 1.1 types:
 | | `xsd:unsignedShort` | 🏗️ | `int` |
 | | `xsd:unsignedInt` | 🏗️ | `int` |
 | | `xsd:unsignedLong` | 🏗️ | `BigInt` |
-| | `xsd:positiveInteger` | 🏗️ | `BigInt` |
+| | `xsd:positiveInteger` | ✅ | `XsdPositiveInteger` / `BigInt` |
 | | `xsd:nonNegativeInteger` | ✅ | `XsdNonNegativeInteger` / `BigInt` |
 | | `xsd:negativeInteger` | ✅ | `XsdNegativeInteger` / `BigInt` |
 | | `xsd:nonPositiveInteger` | ✅ | `XsdNonPositiveInteger` / `BigInt` |

--- a/lib/src/codecs/positive_integer.dart
+++ b/lib/src/codecs/positive_integer.dart
@@ -1,0 +1,103 @@
+import '../core/exceptions.dart';
+import '../core/whitespace.dart';
+import '../core/xsd_codec.dart';
+
+/// Extension type on [BigInt] representing the `xsd:positiveInteger` value space.
+///
+/// Value space: Integers strictly greater than zero ({1, 2, 3, ...}).
+///
+/// This type ensures arbitrary precision and platform consistency by leveraging [BigInt].
+extension type const XsdPositiveInteger._(BigInt value) implements BigInt {
+  static final _regex = RegExp(r'^[\-+]?[0-9]+$');
+
+  /// Validates and creates an [XsdPositiveInteger].
+  ///
+  /// Throws an [ArgumentError] if the [value] is less than or equal to zero.
+  factory XsdPositiveInteger(BigInt value) {
+    if (value <= BigInt.zero) {
+      throw ArgumentError(
+        'Value out of range for XsdPositiveInteger: $value. '
+        'Must be strictly greater than 0.',
+      );
+    }
+    return XsdPositiveInteger._(value);
+  }
+
+  /// Creates an [XsdPositiveInteger] without validation.
+  const XsdPositiveInteger.unsafe(this.value);
+
+  /// Parses an [input] string into an [XsdPositiveInteger].
+  ///
+  /// The [input] must conform to the XSD 1.1 lexical representation:
+  /// `[\-+]?[0-9]+`
+  ///
+  /// Throws a [FormatException] if the [input] is not a valid positive integer.
+  factory XsdPositiveInteger.parse(String input) {
+    if (!_regex.hasMatch(input)) {
+      throw FormatException('Invalid xsd:positiveInteger lexical form: $input');
+    }
+
+    final value = BigInt.parse(input);
+
+    if (value <= BigInt.zero) {
+      throw FormatException(
+        'Value out of range for xsd:positiveInteger: $value',
+      );
+    }
+
+    return XsdPositiveInteger._(value);
+  }
+}
+
+/// Codec for `xsd:positiveInteger`.
+///
+/// According to XSD 1.1:
+/// - Value space: Integers > 0.
+/// - Base type: `xsd:nonNegativeInteger`.
+/// - whiteSpace facet: collapse (fixed)
+/// - pattern: [\-+]?[0-9]+
+class XsdPositiveIntegerCodec extends XsdCodec<XsdPositiveInteger> {
+  /// Creates a new [XsdPositiveIntegerCodec].
+  const XsdPositiveIntegerCodec();
+
+  @override
+  XsdWhitespace get whiteSpace => XsdWhitespace.collapse;
+
+  @override
+  XsdConverter<XsdPositiveInteger, String> get encoder =>
+      const XsdPositiveIntegerEncoder();
+
+  @override
+  XsdConverter<String, XsdPositiveInteger> get decoder =>
+      const XsdPositiveIntegerDecoder();
+}
+
+/// Encoder for `xsd:positiveInteger`.
+class XsdPositiveIntegerEncoder
+    extends XsdConverter<XsdPositiveInteger, String> {
+  /// Creates a new [XsdPositiveIntegerEncoder].
+  const XsdPositiveIntegerEncoder();
+
+  @override
+  String convert(XsdPositiveInteger input) => input.toString();
+}
+
+/// Decoder for `xsd:positiveInteger`.
+class XsdPositiveIntegerDecoder
+    extends XsdConverter<String, XsdPositiveInteger> {
+  /// Creates a new [XsdPositiveIntegerDecoder].
+  const XsdPositiveIntegerDecoder();
+
+  @override
+  XsdPositiveInteger convert(String input) {
+    try {
+      return XsdPositiveInteger.parse(input);
+    } on FormatException catch (e) {
+      throw XsdValidationException(
+        e.message,
+        input: input,
+        type: 'xsd:positiveInteger',
+      );
+    }
+  }
+}

--- a/lib/src/core/facade.dart
+++ b/lib/src/core/facade.dart
@@ -8,6 +8,7 @@ import '../codecs/long.dart';
 import '../codecs/negative_integer.dart';
 import '../codecs/non_negative_integer.dart';
 import '../codecs/non_positive_integer.dart';
+import '../codecs/positive_integer.dart';
 
 /// Global facade for XSD codecs.
 const xsd = XsdFacade._();
@@ -48,4 +49,8 @@ class XsdFacade {
   /// Codec for `xsd:nonPositiveInteger`.
   XsdNonPositiveIntegerCodec get nonPositiveInteger =>
       const XsdNonPositiveIntegerCodec();
+
+  /// Codec for `xsd:positiveInteger`.
+  XsdPositiveIntegerCodec get positiveInteger =>
+      const XsdPositiveIntegerCodec();
 }

--- a/lib/xsd.dart
+++ b/lib/xsd.dart
@@ -13,6 +13,7 @@ export 'src/codecs/long.dart';
 export 'src/codecs/negative_integer.dart';
 export 'src/codecs/non_negative_integer.dart';
 export 'src/codecs/non_positive_integer.dart';
+export 'src/codecs/positive_integer.dart';
 export 'src/core/exceptions.dart';
 export 'src/core/facade.dart';
 export 'src/core/xsd_codec.dart';

--- a/test/codecs/positive_integer_test.dart
+++ b/test/codecs/positive_integer_test.dart
@@ -1,0 +1,89 @@
+import 'package:test/test.dart';
+import 'package:xsd/src/codecs/positive_integer.dart';
+import 'package:xsd/src/core/exceptions.dart';
+
+void main() {
+  group('XsdPositiveInteger', () {
+    test('should allow positive integers', () {
+      final value = XsdPositiveInteger(BigInt.from(100));
+      expect(value, equals(BigInt.from(100)));
+    });
+
+    test('should throw ArgumentError for zero', () {
+      expect(() => XsdPositiveInteger(BigInt.zero), throwsArgumentError);
+    });
+
+    test('should throw ArgumentError for negative integers', () {
+      expect(() => XsdPositiveInteger(BigInt.from(-1)), throwsArgumentError);
+    });
+
+    test('unsafe constructor should not validate', () {
+      final value = XsdPositiveInteger.unsafe(BigInt.from(0));
+      expect(value, equals(BigInt.zero));
+    });
+
+    group('parse', () {
+      test('should parse valid positive integers', () {
+        expect(XsdPositiveInteger.parse('1'), equals(BigInt.one));
+        expect(XsdPositiveInteger.parse('+1'), equals(BigInt.one));
+        expect(XsdPositiveInteger.parse('01'), equals(BigInt.one));
+        expect(
+          XsdPositiveInteger.parse('12345678901234567890'),
+          equals(BigInt.parse('12345678901234567890')),
+        );
+      });
+
+      test('should throw FormatException for zero', () {
+        expect(() => XsdPositiveInteger.parse('0'), throwsFormatException);
+        expect(() => XsdPositiveInteger.parse('+0'), throwsFormatException);
+        expect(() => XsdPositiveInteger.parse('-0'), throwsFormatException);
+      });
+
+      test('should throw FormatException for negative integers', () {
+        expect(() => XsdPositiveInteger.parse('-1'), throwsFormatException);
+      });
+
+      test('should throw FormatException for invalid lexical forms', () {
+        expect(() => XsdPositiveInteger.parse(''), throwsFormatException);
+        expect(() => XsdPositiveInteger.parse('abc'), throwsFormatException);
+        expect(() => XsdPositiveInteger.parse('1.0'), throwsFormatException);
+      });
+    });
+
+    group('XsdPositiveIntegerCodec', () {
+      const codec = XsdPositiveIntegerCodec();
+
+      test('decoder should parse valid strings', () {
+        expect(codec.decode('1'), equals(BigInt.one));
+        expect(codec.decode('123'), equals(BigInt.from(123)));
+        expect(codec.decode('  456  '), equals(BigInt.from(456))); // collapse
+      });
+
+      test(
+        'decoder should throw XsdValidationException for invalid strings',
+        () {
+          expect(
+            () => codec.decode('0'),
+            throwsA(isA<XsdValidationException>()),
+          );
+          expect(
+            () => codec.decode('-1'),
+            throwsA(isA<XsdValidationException>()),
+          );
+          expect(
+            () => codec.decode('abc'),
+            throwsA(isA<XsdValidationException>()),
+          );
+        },
+      );
+
+      test('encoder should produce canonical strings', () {
+        expect(codec.encode(XsdPositiveInteger(BigInt.one)), equals('1'));
+        expect(
+          codec.encode(XsdPositiveInteger(BigInt.from(100))),
+          equals('100'),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
- Add `XsdPositiveInteger` extension type for arbitrary-precision positive integers.
- Implement `XsdPositiveIntegerCodec`, `XsdPositiveIntegerEncoder`, and `XsdPositiveIntegerDecoder`.
- Register `positiveInteger` in the `xsd` facade and export from `lib/xsd.dart`.
- Add unit tests in `test/codecs/positive_integer_test.dart`.
- Update `README.md` implementation status.