### PR TITLE
feat(codecs): implement xsd:short codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ We are incrementally implementing the RDF-compatible subset of XSD 1.1 types:
 | | `xsd:yearMonthDuration` | 🏗️ | `XsdDuration` |
 | | `xsd:dayTimeDuration` | 🏗️ | `XsdDuration` |
 | **Limited-range Integers** | `xsd:byte` | ✅ | `XsdByte` |
-| | `xsd:short` | 🏗️ | `int` |
+| | `xsd:short` | ✅ | `XsdShort` / `int` |
 | | `xsd:int` | ✅ | `XsdInt` |
 | | `xsd:long` | ✅ | `XsdLong` / `BigInt` |
 | | `xsd:unsignedByte` | 🏗️ | `int` |

--- a/lib/src/codecs/short.dart
+++ b/lib/src/codecs/short.dart
@@ -6,12 +6,18 @@ import '../core/xsd_codec.dart';
 ///
 /// Value space: Integers in the range `[-32768, 32767]`.
 extension type const XsdShort._(int value) implements int {
+  /// The minimum value for an `xsd:short`, equal to -2^15.
+  static const int min = -32768;
+
+  /// The maximum value for an `xsd:short`, equal to 2^15 - 1.
+  static const int max = 32767;
+
   /// Validates and creates an [XsdShort].
   ///
-  /// Throws an [ArgumentError] if the value is outside the range `[-32768, 32767]`.
+  /// Throws a [RangeError] if the value is outside the range `[-32768, 32767]`.
   factory XsdShort(int value) {
-    if (value < -32768 || value > 32767) {
-      throw RangeError.range(value, -32768, 32767, 'XsdShort');
+    if (value < min || value > max) {
+      throw RangeError.range(value, min, max, 'XsdShort');
     }
     return XsdShort._(value);
   }
@@ -67,9 +73,10 @@ class XsdShortDecoder extends XsdConverter<String, XsdShort> {
       );
     }
 
-    final value = int.parse(input);
+    final value = BigInt.parse(input);
 
-    if (value < -32768 || value > 32767) {
+    if (value < BigInt.from(XsdShort.min) ||
+        value > BigInt.from(XsdShort.max)) {
       throw XsdValidationException(
         'Value out of range for xsd:short: $value',
         input: input,
@@ -77,6 +84,6 @@ class XsdShortDecoder extends XsdConverter<String, XsdShort> {
       );
     }
 
-    return XsdShort.unsafe(value);
+    return XsdShort.unsafe(value.toInt());
   }
 }

--- a/lib/src/codecs/short.dart
+++ b/lib/src/codecs/short.dart
@@ -1,0 +1,82 @@
+import '../core/exceptions.dart';
+import '../core/whitespace.dart';
+import '../core/xsd_codec.dart';
+
+/// Extension type on [int] representing the `xsd:short` value space.
+///
+/// Value space: Integers in the range `[-32768, 32767]`.
+extension type const XsdShort._(int value) implements int {
+  /// Validates and creates an [XsdShort].
+  ///
+  /// Throws an [ArgumentError] if the value is outside the range `[-32768, 32767]`.
+  factory XsdShort(int value) {
+    if (value < -32768 || value > 32767) {
+      throw RangeError.range(value, -32768, 32767, 'XsdShort');
+    }
+    return XsdShort._(value);
+  }
+
+  /// Creates an [XsdShort] without validation.
+  const XsdShort.unsafe(this.value);
+}
+
+/// Codec for `xsd:short`.
+///
+/// According to XSD 1.1:
+/// - Value space: Integers in the range `[-32768, 32767]`.
+/// - Base type: `xsd:int`.
+/// - whiteSpace facet: collapse (fixed)
+/// - pattern: [\-+]?[0-9]+
+class XsdShortCodec extends XsdCodec<XsdShort> {
+  /// Creates a new [XsdShortCodec].
+  const XsdShortCodec();
+
+  @override
+  XsdWhitespace get whiteSpace => XsdWhitespace.collapse;
+
+  @override
+  XsdConverter<XsdShort, String> get encoder => const XsdShortEncoder();
+
+  @override
+  XsdConverter<String, XsdShort> get decoder => const XsdShortDecoder();
+}
+
+/// Encoder for `xsd:short`.
+class XsdShortEncoder extends XsdConverter<XsdShort, String> {
+  /// Creates a new [XsdShortEncoder].
+  const XsdShortEncoder();
+
+  @override
+  String convert(XsdShort input) => input.toString();
+}
+
+/// Decoder for `xsd:short`.
+class XsdShortDecoder extends XsdConverter<String, XsdShort> {
+  /// Creates a new [XsdShortDecoder].
+  const XsdShortDecoder();
+
+  static final RegExp _pattern = RegExp(r'^[\-+]?[0-9]+$');
+
+  @override
+  XsdShort convert(String input) {
+    if (!_pattern.hasMatch(input)) {
+      throw XsdValidationException(
+        'Invalid xsd:short lexical representation.',
+        input: input,
+        type: 'xsd:short',
+      );
+    }
+
+    final value = int.parse(input);
+
+    if (value < -32768 || value > 32767) {
+      throw XsdValidationException(
+        'Value out of range for xsd:short: $value',
+        input: input,
+        type: 'xsd:short',
+      );
+    }
+
+    return XsdShort.unsafe(value);
+  }
+}

--- a/lib/src/core/facade.dart
+++ b/lib/src/core/facade.dart
@@ -9,6 +9,7 @@ import '../codecs/negative_integer.dart';
 import '../codecs/non_negative_integer.dart';
 import '../codecs/non_positive_integer.dart';
 import '../codecs/positive_integer.dart';
+import '../codecs/short.dart';
 
 /// Global facade for XSD codecs.
 const xsd = XsdFacade._();
@@ -53,4 +54,7 @@ class XsdFacade {
   /// Codec for `xsd:positiveInteger`.
   XsdPositiveIntegerCodec get positiveInteger =>
       const XsdPositiveIntegerCodec();
+
+  /// Codec for `xsd:short`.
+  XsdShortCodec get short => const XsdShortCodec();
 }

--- a/lib/xsd.dart
+++ b/lib/xsd.dart
@@ -14,6 +14,7 @@ export 'src/codecs/negative_integer.dart';
 export 'src/codecs/non_negative_integer.dart';
 export 'src/codecs/non_positive_integer.dart';
 export 'src/codecs/positive_integer.dart';
+export 'src/codecs/short.dart';
 export 'src/core/exceptions.dart';
 export 'src/core/facade.dart';
 export 'src/core/xsd_codec.dart';

--- a/test/codecs/short_test.dart
+++ b/test/codecs/short_test.dart
@@ -1,0 +1,75 @@
+import 'package:test/test.dart';
+import 'package:xsd/src/codecs/short.dart';
+import 'package:xsd/src/core/exceptions.dart';
+
+void main() {
+  group('XsdShort', () {
+    test('XsdShort() allows values in range [-32768, 32767]', () {
+      expect(XsdShort(-32768).value, equals(-32768));
+      expect(XsdShort(0).value, equals(0));
+      expect(XsdShort(32767).value, equals(32767));
+    });
+
+    test('XsdShort() throws RangeError for values out of range', () {
+      expect(() => XsdShort(-32769), throwsRangeError);
+      expect(() => XsdShort(32768), throwsRangeError);
+    });
+
+    test('XsdShort.unsafe() bypasses validation', () {
+      expect(XsdShort.unsafe(32768).value, equals(32768));
+    });
+  });
+
+  group('XsdShortCodec', () {
+    const codec = XsdShortCodec();
+
+    group('decode', () {
+      test('successfully decodes valid lexical forms', () {
+        expect(codec.decode('123'), equals(XsdShort(123)));
+        expect(codec.decode('+123'), equals(XsdShort(123)));
+        expect(codec.decode('-123'), equals(XsdShort(-123)));
+        expect(codec.decode('0'), equals(XsdShort(0)));
+        expect(codec.decode('000123'), equals(XsdShort(123)));
+        expect(
+          codec.decode(' 123 '),
+          equals(XsdShort(123)),
+        ); // Whitespace collapse
+      });
+
+      test('throws XsdValidationException for invalid lexical forms', () {
+        expect(() => codec.decode(''), throwsA(isA<XsdValidationException>()));
+        expect(
+          () => codec.decode('abc'),
+          throwsA(isA<XsdValidationException>()),
+        );
+        expect(
+          () => codec.decode('12.3'),
+          throwsA(isA<XsdValidationException>()),
+        );
+        expect(
+          () => codec.decode('++123'),
+          throwsA(isA<XsdValidationException>()),
+        );
+      });
+
+      test('throws XsdValidationException for out of range values', () {
+        expect(
+          () => codec.decode('32768'),
+          throwsA(isA<XsdValidationException>()),
+        );
+        expect(
+          () => codec.decode('-32769'),
+          throwsA(isA<XsdValidationException>()),
+        );
+      });
+    });
+
+    group('encode', () {
+      test('successfully encodes to canonical form', () {
+        expect(codec.encode(XsdShort(123)), equals('123'));
+        expect(codec.encode(XsdShort(-123)), equals('-123'));
+        expect(codec.encode(XsdShort(0)), equals('0'));
+      });
+    });
+  });
+}

--- a/test/codecs/short_test.dart
+++ b/test/codecs/short_test.dart
@@ -61,6 +61,10 @@ void main() {
           () => codec.decode('-32769'),
           throwsA(isA<XsdValidationException>()),
         );
+        expect(
+          () => codec.decode('999999999999999999999'),
+          throwsA(isA<XsdValidationException>()),
+        );
       });
     });
 


### PR DESCRIPTION
- Add `XsdShort` extension type on `int` for 16-bit signed integers.
- Implement `XsdShortCodec`, `XsdShortEncoder`, and `XsdShortDecoder`.
- Add range validation for `[-32768, 32767]`.
- Register `short` in the `xsd` facade and export from `lib/xsd.dart`.
- Add unit tests in `test/codecs/short_test.dart`.
- Update `README.md` implementation status for `xsd:short`.